### PR TITLE
Pathmodel 0.2.0

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -972,8 +972,8 @@ In the GitHub repository (`pathmodel/pathmodel/data/ <https://github.com/pathmod
 
 - ``MAA_pwy.lp``: Mycosporine Amino-Acids Like pathways according to data from *Chondrus crispus* (`Belcour et al, 2020 <https://doi.org/10.1016/j.isci.2020.100849>`__).
 - ``sterol_pwy.lp``: Sterol pathways according to data from *Chondrus crispus* (`Belcour et al, 2020 <https://doi.org/10.1016/j.isci.2020.100849>`__).
-- ``brown_sterols_pwy.lp``: Sterol pathways in Brown algae (Girard et al., *paper in preparation*).
-- ``mozukulins_pwy.lp``: Mozukulins and sterol pathway in the brown alga *Cladosiphon okamuranus* (Girard et al., *paper in preparation*).
+- ``brown_sterols_pwy.lp``: Sterol pathways in Brown algae (`Girard et al., 2021 <https://doi.org/10.3389/fpls.2021.648426>`__).
+- ``mozukulins_pwy.lp``: Mozukulins and sterol pathway in the brown alga *Cladosiphon okamuranus* (`Girard et al., 2021 <https://doi.org/10.3389/fpls.2021.648426>`__).
 
 
 Citation

--- a/README.rst
+++ b/README.rst
@@ -566,7 +566,7 @@ PathModel creates also a picture showing all the reactions (known reactions in g
    |    :width: 400px                           |
    +--------------------------------------------+
 
-Tutorial on Article data (*Chondrus crispus* sterol and Mycosporine-like Amino Acids pathways)
+Tutorial on *iScience* Article data (*Chondrus crispus* sterol and Mycosporine-like Amino Acids pathways)
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 PathModel contains script to reproduce the experience run in the article: analysis of *Chondrus crispus* sterol and Mycosporine-like Amino Acids (MAA) pathways.

--- a/README.rst
+++ b/README.rst
@@ -17,7 +17,7 @@
 PathModel: metabolic pathway drift prototype
 ============================================
 
-PathModel is a prototype to infer new biochemical reactions and new metabolite structures. The biological motivation for developing it is described in this `article <https://doi.org/10.1016/j.isci.2020.100849>`__, published in `iScience <https://www.cell.com/iscience/home>`__.
+PathModel is a prototype to infer new biochemical reactions and new metabolite structures. The biological motivation for developing it is described in this `article <https://doi.org/10.1016/j.isci.2020.100849>`__, published in `iScience <https://www.cell.com/iscience/home>`__.  You can also watch the associated presentation at the `JOBIM2020 conference: <https://relaiswebcasting.mediasite.com/mediasite/Play/55fa04573fd14bd5bf3b31acff74cb131d?catalog=e534823f0c954836bf85bfa80af2290921>`__.
 
 There is no guarantee that this script will work, it is a Work In Progress in early state.
 

--- a/README.rst
+++ b/README.rst
@@ -282,7 +282,17 @@ Run PathModel prediction:
 
 .. code:: sh
 
-	pathmodel infer -i data.lp -o output_folder
+	pathmodel infer -i data.lp -o output_folder -s 100
+
+PathModel arguments:
+
+- -i: input file
+
+- -o: output folder
+
+- -s: number of maximal steps before PathModel stops (to avoid endless run), by default at 100
+
+If PathModel does not find the goal molecules before it reaches the number of maximal steps, it will send an error message.
 
 Create picture representing the results (like new molecules inferred from M/Z ratio):
 
@@ -296,7 +306,7 @@ In python (pathmodel_plot is not available in import call):
 
     import pathmodel
 
-    pathmodel.pathmodel_analysis('data.lp', output_folder)
+    pathmodel.pathmodel_analysis('data.lp', output_folder, step_limit=100)
 
 Output
 ~~~~~~

--- a/README.rst
+++ b/README.rst
@@ -905,8 +905,8 @@ The structures of the predicted molecules from M/Z can be found in newmolecules_
 
 - Prediction_3023117_decarboxylation_1 and Prediction_3023117_decarboxylation_2 (which are the same molecule) correspond to MAA2.
 
-This molecule has been identified as the Aplysiapalythine A found in *Aplysia californica* by `Kamio et al. (2011) <https://onlinelibrary.wiley.com/doi/abs/10.1002/hlca.201100117>`__.
-Furthermore, Aplysiapalythine A has been detected in red algae (the group in which *Chondrus crispus* is classified) by `Orfanoudaki et al. (2019) <https://onlinelibrary.wiley.com/doi/full/10.1111/jpy.12827>`__.
+This molecule has been identified as the Aplysiapalythine A found in *Aplysia californica* by [Kamio2011]_.
+Furthermore, Aplysiapalythine A has been detected in red algae (the group in which *Chondrus crispus* is classified) by [Orfanoudaki2019]_.
 
 .. table::
    :align: center
@@ -975,6 +975,6 @@ Arnaud Belcour, Jean Girard, Méziane Aite, Ludovic Delage, Camille Trottier, Ch
 Bibliography
 ------------
 
-Kamio, M., Kicklighter, C.E., Nguyen, L., Germann, M.W. and Derby, C.D. (2011). Isolation and Structural Elucidation of Novel Mycosporine‐Like Amino Acids as Alarm Cues in the Defensive Ink Secretion of the Sea Hare *Aplysia californica*. *Helvetica Chimica Acta*, 94: 1012-1018. `doi:10.1002/hlca.201100117 <https://doi.org/10.1002/hlca.201100117>`__.
+.. [Kamio2011] Kamio, M., Kicklighter, C.E., Nguyen, L., Germann, M.W. and Derby, C.D. (2011). Isolation and Structural Elucidation of Novel Mycosporine‐Like Amino Acids as Alarm Cues in the Defensive Ink Secretion of the Sea Hare *Aplysia californica*. *Helvetica Chimica Acta*, 94: 1012-1018. `doi:10.1002/hlca.201100117 <https://doi.org/10.1002/hlca.201100117>`__.
 
-Orfanoudaki, M., Hartmann, A., Karsten, U. and Ganzera, M. (2019). Chemical profiling of mycosporine‐like amino acids in twenty‐three red algal species. *Journal of Phycology*, 55: 393-403. `doi:10.1111/jpy.12827 <https://doi.org/10.1111/jpy.12827>`__.
+.. [Orfanoudaki2019] Orfanoudaki, M., Hartmann, A., Karsten, U. and Ganzera, M. (2019). Chemical profiling of mycosporine‐like amino acids in twenty‐three red algal species. *Journal of Phycology*, 55: 393-403. `doi:10.1111/jpy.12827 <https://doi.org/10.1111/jpy.12827>`__.

--- a/README.rst
+++ b/README.rst
@@ -968,12 +968,12 @@ Furthermore, Aplysiapalythine A has been detected in red algae (the group in whi
 Data
 ----
 
-In the GitHub repository (`pathmodel/pathmodel/data/ <https://github.com/pathmodel/pathmodel/tree/master/pathmodel/data>`__), there is 4 data files:
+In the GitHub repository (`pathmodel/pathmodel/data/ <https://github.com/pathmodel/pathmodel/tree/master/pathmodel/data>`__), there are 4 data files:
 
 - ``MAA_pwy.lp``: Mycosporine Amino-Acids Like pathways according to data from *Chondrus crispus* (`Belcour et al, 2020 <https://doi.org/10.1016/j.isci.2020.100849>`__).
 - ``sterol_pwy.lp``: Sterol pathways according to data from *Chondrus crispus* (`Belcour et al, 2020 <https://doi.org/10.1016/j.isci.2020.100849>`__).
-- ``brown_sterols_pwy.lp``: Sterol pathways in Brown algae.
-- ``mozukulins_pwy.lp``: Mozukulins and sterol pathway.
+- ``brown_sterols_pwy.lp``: Sterol pathways in Brown algae (Girard et al., *paper in preparation*).
+- ``mozukulins_pwy.lp``: Mozukulins and sterol pathway in the brown alga *Cladosiphon okamuranus* (Girard et al., *paper in preparation*).
 
 
 Citation

--- a/README.rst
+++ b/README.rst
@@ -905,8 +905,8 @@ The structures of the predicted molecules from M/Z can be found in newmolecules_
 
 - Prediction_3023117_decarboxylation_1 and Prediction_3023117_decarboxylation_2 (which are the same molecule) correspond to MAA2.
 
-This molecule has been identified as the Aplysiapalythine A found in *Aplysia californica* by [Kamio2011]_.
-Furthermore, Aplysiapalythine A has been detected in red algae (the group in which *Chondrus crispus* is classified) by [Orfanoudaki2019]_.
+This molecule has been identified as the Aplysiapalythine A found in *Aplysia californica* [Kamio2011]_.
+Furthermore, Aplysiapalythine A has been detected in red algae (the group in which *Chondrus crispus* is classified) [Orfanoudaki2019]_.
 
 .. table::
    :align: center

--- a/README.rst
+++ b/README.rst
@@ -17,7 +17,7 @@
 PathModel: metabolic pathway drift prototype
 ============================================
 
-PathModel is a prototype to infer new biochemical reactions and new metabolite structures. The biological motivation for developing it is described in this `article <https://doi.org/10.1016/j.isci.2020.100849>`__, published in `iScience <https://www.cell.com/iscience/home>`__.  You can also watch the associated presentation at the `JOBIM2020 conference <https://relaiswebcasting.mediasite.com/mediasite/Play/55fa04573fd14bd5bf3b31acff74cb131d?catalog=e534823f0c954836bf85bfa80af2290921>`__.
+PathModel is a prototype to infer new biochemical reactions and new metabolite structures. The biological motivation for developing it is described in this `article <https://doi.org/10.1016/j.isci.2020.100849>`__, published in `iScience <https://www.cell.com/iscience/home>`__.  You can also watch the `associated presentation<https://relaiswebcasting.mediasite.com/mediasite/Play/55fa04573fd14bd5bf3b31acff74cb131d?catalog=e534823f0c954836bf85bfa80af2290921>`__ at the `JOBIM2020 conference <https://jobim2020.sciencesconf.org/>`__.
 
 There is no guarantee that this script will work, it is a Work In Progress in early state.
 

--- a/README.rst
+++ b/README.rst
@@ -14,8 +14,8 @@
         :target: https://www.cell.com/iscience/fulltext/S2589-0042(20)30032-8
 
 
-PathModel: metabolic pathway drift prototype
-============================================
+PathModel: inferring new biochemical reactions and metabolite structures to understand metabolic pathway drift 
+==============================================================================================================
 
 PathModel is a prototype to infer new biochemical reactions and new metabolite structures. The biological motivation for developing it is described in this `article <https://doi.org/10.1016/j.isci.2020.100849>`__, published in `iScience <https://www.cell.com/iscience/home>`__.  You can also watch the `associated presentation <https://relaiswebcasting.mediasite.com/mediasite/Play/55fa04573fd14bd5bf3b31acff74cb131d?catalog=e534823f0c954836bf85bfa80af2290921>`__ at the `JOBIM2020 conference <https://jobim2020.sciencesconf.org/>`__.
 

--- a/README.rst
+++ b/README.rst
@@ -17,7 +17,7 @@
 PathModel: metabolic pathway drift prototype
 ============================================
 
-PathModel is a prototype to infer new biochemical reactions and new metabolite structures. The biological motivation for developing it is described in this `article <https://doi.org/10.1016/j.isci.2020.100849>`__, published in `iScience <https://www.cell.com/iscience/home>`__.  You can also watch the `associated presentation<https://relaiswebcasting.mediasite.com/mediasite/Play/55fa04573fd14bd5bf3b31acff74cb131d?catalog=e534823f0c954836bf85bfa80af2290921>`__ at the `JOBIM2020 conference <https://jobim2020.sciencesconf.org/>`__.
+PathModel is a prototype to infer new biochemical reactions and new metabolite structures. The biological motivation for developing it is described in this `article <https://doi.org/10.1016/j.isci.2020.100849>`__, published in `iScience <https://www.cell.com/iscience/home>`__.  You can also watch the `associated presentation <https://relaiswebcasting.mediasite.com/mediasite/Play/55fa04573fd14bd5bf3b31acff74cb131d?catalog=e534823f0c954836bf85bfa80af2290921>`__ at the `JOBIM2020 conference <https://jobim2020.sciencesconf.org/>`__.
 
 There is no guarantee that this script will work, it is a Work In Progress in early state.
 

--- a/README.rst
+++ b/README.rst
@@ -17,7 +17,7 @@
 PathModel: metabolic pathway drift prototype
 ============================================
 
-PathModel is a prototype to infer new biochemical reactions and new metabolite structures. The biological motivation for developing it is described in this `article <https://doi.org/10.1016/j.isci.2020.100849>`__, published in `iScience <https://www.cell.com/iscience/home>`__.  You can also watch the associated presentation at the `JOBIM2020 conference: <https://relaiswebcasting.mediasite.com/mediasite/Play/55fa04573fd14bd5bf3b31acff74cb131d?catalog=e534823f0c954836bf85bfa80af2290921>`__.
+PathModel is a prototype to infer new biochemical reactions and new metabolite structures. The biological motivation for developing it is described in this `article <https://doi.org/10.1016/j.isci.2020.100849>`__, published in `iScience <https://www.cell.com/iscience/home>`__.  You can also watch the associated presentation at the `JOBIM2020 conference <https://relaiswebcasting.mediasite.com/mediasite/Play/55fa04573fd14bd5bf3b31acff74cb131d?catalog=e534823f0c954836bf85bfa80af2290921>`__.
 
 There is no guarantee that this script will work, it is a Work In Progress in early state.
 

--- a/README.rst
+++ b/README.rst
@@ -965,6 +965,17 @@ Furthermore, Aplysiapalythine A has been detected in red algae (the group in whi
    | predictbond("Prediction_3023117_decarboxylation_1",single,19,24). | predictbond("Prediction_3023117_decarboxylation_2",single,19,24). |
    +-------------------------------------------------------------------+-------------------------------------------------------------------+
 
+Data
+----
+
+In the GitHub repository (`pathmodel/pathmodel/data/ <https://github.com/pathmodel/pathmodel/tree/master/pathmodel/data>`__), there is 4 data files:
+
+- ``MAA_pwy.lp``: Mycosporine Amino-Acids Like pathways according to data from *Chondrus crispus* (`Belcour et al, 2020 <https://doi.org/10.1016/j.isci.2020.100849>`__).
+- ``sterol_pwy.lp``: Sterol pathways according to data from *Chondrus crispus* (`Belcour et al, 2020 <https://doi.org/10.1016/j.isci.2020.100849>`__).
+- ``brown_sterols_pwy.lp``: Sterol pathways in Brown algae.
+- ``mozukulins_pwy.lp``: Mozukulins and sterol pathway.
+
+
 Citation
 --------
 

--- a/pathmodel/__init__.py
+++ b/pathmodel/__init__.py
@@ -1,2 +1,3 @@
 from pathmodel.pathmodel_wrapper import check_folder, mz_computation, reaction_creation, pathmodel_inference, pathmodel_analysis
 
+__version__='0.1.9'

--- a/pathmodel/__init__.py
+++ b/pathmodel/__init__.py
@@ -1,3 +1,3 @@
 from pathmodel.pathmodel_wrapper import check_folder, mz_computation, reaction_creation, pathmodel_inference, pathmodel_analysis
 
-__version__='0.1.9'
+__version__='0.2.0'

--- a/pathmodel/__main__.py
+++ b/pathmodel/__main__.py
@@ -30,6 +30,14 @@ def main():
         required=True,
         help="output directory path",
         metavar="OUPUT_DIR")
+    parent_parser_s = argparse.ArgumentParser(add_help=False)
+    parent_parser_s.add_argument(
+        "-s",
+        "--step-limit",
+        dest="step_limit",
+        required=False,
+        help="set a maximal number of step to avoid endless run of pathmodel (by default at 100)",
+        metavar="INT")
 
     # subparsers
     subparsers = parser.add_subparsers(
@@ -40,7 +48,7 @@ def main():
         "infer",
         help="PathModel inference on data",
         parents=[
-            parent_parser_i, parent_parser_o
+            parent_parser_i, parent_parser_o, parent_parser_s
         ],
         description=
         "Run PathModel on input data lp file"
@@ -75,14 +83,15 @@ def main():
         check_folder(sterol_out)
         check_folder(maa_out)
 
-        pathmodel_analysis(sterol_input_path, sterol_out)
-        pathmodel_analysis(maa_input_path, maa_out)
+        pathmodel_analysis(sterol_input_path, sterol_out, None)
+        pathmodel_analysis(maa_input_path, maa_out, None)
 
         return
 
     elif parser_args.cmd == 'infer':
         input_file = parser_args.input
-        pathmodel_analysis(input_file, output_folder)
+        step_limit = parser_args.step_limit
+        pathmodel_analysis(input_file, output_folder, step_limit)
 
 if __name__ == "__main__":
     main()

--- a/pathmodel/__main__.py
+++ b/pathmodel/__main__.py
@@ -74,11 +74,12 @@ def main():
     output_folder = parser_args.output_folder
 
     if parser_args.cmd == 'test':
-        package_path = '/'.join(os.path.realpath(__file__).split('/')[:-1])+ '/data/'
-        sterol_input_path = package_path + 'sterol_pwy.lp'
-        maa_input_path = package_path + 'MAA_pwy.lp'
-        sterol_out = output_folder + '/sterol'
-        maa_out = output_folder + '/MAA'
+        package_path = os.path.dirname(os.path.realpath(__file__))
+        data_package_path = os.path.join(package_path, 'data')
+        sterol_input_path = os.path.join(data_package_path, 'sterol_pwy.lp')
+        maa_input_path = os.path.join(data_package_path, 'MAA_pwy.lp')
+        sterol_out = os.path.join(output_folder, 'sterol')
+        maa_out = os.path.join(output_folder, 'MAA')
 
         check_folder(sterol_out)
         check_folder(maa_out)

--- a/pathmodel/asp/CompareMolecules.lp
+++ b/pathmodel/asp/CompareMolecules.lp
@@ -1,0 +1,18 @@
+ %*
+Search difference between molecules occurring in the same reaction.
+This script is used to check if reactions are well encoded.
+*%
+
+%* Test to see difference between two molecules
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+*%
+
+diffMolecules(ReactionName, MoleculeName1, MoleculeName2, BondType, FirstAtomNumber, SecondAtomNumber):-
+		    bond(MoleculeName1, BondType, FirstAtomNumber, SecondAtomNumber),
+		not bond(MoleculeName2, BondType, FirstAtomNumber, SecondAtomNumber), compareMolecules(ReactionName, MoleculeName1, MoleculeName2).
+
+compareMolecules(ReactionName,Reactant, Product):- compareMolecules(ReactionName, Product, Reactant).
+
+compareMolecules(ReactionName, Reactant, Product):- reaction(ReactionName, Reactant, Product).
+
+#show diffMolecules/6.

--- a/pathmodel/asp/PathModel.lp
+++ b/pathmodel/asp/PathModel.lp
@@ -279,10 +279,11 @@ bond(ProductName,BondType,FirstAtomeNumber,SecondAtomeNumber):- reaction(Reactio
 bond(ProductName,BondType,FirstAtomeNumber,SecondAtomeNumber):- reaction(Reaction,ReactantName,ProductName); diffBondAfterReaction(Reaction,BondType,FirstAtomeNumber,SecondAtomeNumber).
 
 #program check(t).
-:- goal(F), query(t), not inferred(F,t).
+:- goal(F), query(t), not inferred(F,t), t<Tlimit, step_limit(Tlimit).
 
 #show newreaction/3.
 #show reaction/3.
 #show inferred/2.
 #show predictatom/3.
 #show predictbond/4.
+#show query/1.

--- a/pathmodel/asp/PathModel.lp
+++ b/pathmodel/asp/PathModel.lp
@@ -87,10 +87,14 @@ reached(KnownProduct, t):- source(KnownReactant), reaction(ReactionName, KnownRe
 % Add product found by inference methods.
 source(ProductInferred):- source(Reactant), reaction(ReactionName, Reactant, ProductInferred), reached(ProductInferred, t).
 
+% Add inference steps from previous step.
+inferred(pathway(Molecule1,ProductInferred), t):- inferred(pathway(Molecule1,ProductInferred), t-1).
+
+% Add inference when we reach a new molecule.
 inferred(pathway(Molecule1,Molecule2), t):- reaction(ReactionName,Molecule1,Molecule2), reached(Molecule2, t).
-inferred(pathway(Molecule1,ProductInferred), t):- reaction(ReactionName,Molecule2,ProductInferred), reached(ProductInferred, t), inferred(pathway(Molecule1,Molecule2), t-1).
-% Error with inferred (need to keep older inferred?)
-inferred(pathway(Molecule1,ProductInferred), t):-inferred(pathway(Molecule1,ProductInferred), t-1).
+
+% Add inference when we reach the product of a previous inference.
+inferred(pathway(Molecule1,ProductInferred), t):- reaction(ReactionName,Molecule2,ProductInferred), reached(ProductInferred, t), inferred(pathway(Molecule1,Molecule2), T2), T2 < t.
 
 
 %* Metabolite Inference Method

--- a/pathmodel/asp/PathModel.lp
+++ b/pathmodel/asp/PathModel.lp
@@ -40,20 +40,6 @@ metabolite(MoleculeName):- atom(MoleculeName,_,_).
 
 #program step(t).
 
-%* Test to see difference between two molecules
-%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
-*%
-%*
-difmolecules(MoleculeName1, MoleculeName2, BondType, FirstAtomNumber, SecondAtomNumber,direct):-
-		    bond(MoleculeName1, BondType, FirstAtomNumber, SecondAtomNumber),
-		not bond(MoleculeName2, BondType, FirstAtomNumber, SecondAtomNumber), testeddif(MoleculeName1, MoleculeName2).
-
-testeddif("z-palythenic acid", "palythene").
-testeddif("4α-methylcholest-8(9),14,24,trien-3β-ol", "4α-methylzymosterol").
-testeddif(B,A):-testeddif(A,B).
-
-*%
-
 %* Browse reactions
 %%%%%%%%%%%%%%%%%%%%
 Move from molecule A to molecule B using reaction(ReactionName,A,B). A pathway is here described as the path from a molecule to another through reactions.

--- a/pathmodel/data/brown_sterols_pwy.lp
+++ b/pathmodel/data/brown_sterols_pwy.lp
@@ -1,4 +1,4 @@
-%*This is work in progress for a paper by Girard et al., to be submitted to Frontiers in Plant Science, and has not yet been peer reviewed. 
+%*This is work in progress for a paper by Girard et al., to be submitted to Frontiers in Plant Science, and is now under interactive review. 
 *%
 
 %*
@@ -25,20 +25,33 @@ bond("cycloartenol",singleR,17,20). bond("cycloartenol",singleS,20,21). bond("cy
 bond("cycloartenol",single,22,23). bond("cycloartenol",single,23,24). bond("cycloartenol",double,24,25).
 bond("cycloartenol",single,25,26). bond("cycloartenol",single,25,27).
 
-atom("stigmasterol",1..24,carb). atom("stigmasterol",241,carb). atom("stigmasterol",242,carb).
-atom("stigmasterol",25..27,carb). atom("stigmasterol",31,oxyg).
-bond("stigmasterol",single,1,2). bond("stigmasterol",single,1,10). bond("stigmasterol",single,2,3).
-bond("stigmasterol",single,3,4). bond("stigmasterol",singleR,3,31). bond("stigmasterol",single,4,5).
-bond("stigmasterol",double,5,6). bond("stigmasterol",single,5,10). bond("stigmasterol",single,6,7).
-bond("stigmasterol",single,7,8). bond("stigmasterol",single,8,9). bond("stigmasterol",single,8,14).
-bond("stigmasterol",single,9,10). bond("stigmasterol",single,9,11). bond("stigmasterol",singleR,10,19).
-bond("stigmasterol",single,11,12). bond("stigmasterol",single,12,13). bond("stigmasterol",single,13,14).
-bond("stigmasterol",single,14,15). bond("stigmasterol",single,15,16). bond("stigmasterol",single,16,17).
-bond("stigmasterol",single,13,17). bond("stigmasterol",singleR,13,18). bond("stigmasterol",singleR,17,20).
-bond("stigmasterol",singleS,20,21). bond("stigmasterol",single,20,22). bond("stigmasterol",double,22,23).
-bond("stigmasterol",single,23,24). bond("stigmasterol",singleR,24,241). bond("stigmasterol",single,241,242).
-bond("stigmasterol",single,24,25). bond("stigmasterol",single,25,26). bond("stigmasterol",single,25,27).
+atom("24-ethylcholest-22-enol",1..24,carb). atom("24-ethylcholest-22-enol",241,carb). atom("24-ethylcholest-22-enol",242,carb).
+atom("24-ethylcholest-22-enol",25..27,carb). atom("24-ethylcholest-22-enol",31,oxyg).
+bond("24-ethylcholest-22-enol",single,1,2). bond("24-ethylcholest-22-enol",single,1,10). bond("24-ethylcholest-22-enol",single,2,3).
+bond("24-ethylcholest-22-enol",single,3,4). bond("24-ethylcholest-22-enol",singleR,3,31). bond("24-ethylcholest-22-enol",single,4,5).
+bond("24-ethylcholest-22-enol",double,5,6). bond("24-ethylcholest-22-enol",single,5,10). bond("24-ethylcholest-22-enol",single,6,7).
+bond("24-ethylcholest-22-enol",single,7,8). bond("24-ethylcholest-22-enol",single,8,9). bond("24-ethylcholest-22-enol",single,8,14).
+bond("24-ethylcholest-22-enol",single,9,10). bond("24-ethylcholest-22-enol",single,9,11). bond("24-ethylcholest-22-enol",singleR,10,19).
+bond("24-ethylcholest-22-enol",single,11,12). bond("24-ethylcholest-22-enol",single,12,13). bond("24-ethylcholest-22-enol",single,13,14).
+bond("24-ethylcholest-22-enol",single,14,15). bond("24-ethylcholest-22-enol",single,15,16). bond("24-ethylcholest-22-enol",single,16,17).
+bond("24-ethylcholest-22-enol",single,13,17). bond("24-ethylcholest-22-enol",singleR,13,18). bond("24-ethylcholest-22-enol",singleR,17,20).
+bond("24-ethylcholest-22-enol",singleS,20,21). bond("24-ethylcholest-22-enol",single,20,22). bond("24-ethylcholest-22-enol",double,22,23).
+bond("24-ethylcholest-22-enol",single,23,24). bond("24-ethylcholest-22-enol",single,24,241). bond("24-ethylcholest-22-enol",single,241,242).
+bond("24-ethylcholest-22-enol",single,24,25). bond("24-ethylcholest-22-enol",single,25,26). bond("24-ethylcholest-22-enol",single,25,27).
 
+atom("24-ethylcholesterol",1..24,carb). atom("24-ethylcholesterol",241,carb). atom("24-ethylcholesterol",242,carb).
+atom("24-ethylcholesterol",25..27,carb). atom("24-ethylcholesterol",31,oxyg).
+bond("24-ethylcholesterol",single,1,2). bond("24-ethylcholesterol",single,1,10). bond("24-ethylcholesterol",single,2,3).
+bond("24-ethylcholesterol",single,3,4). bond("24-ethylcholesterol",singleR,3,31). bond("24-ethylcholesterol",single,4,5).
+bond("24-ethylcholesterol",double,5,6). bond("24-ethylcholesterol",single,5,10). bond("24-ethylcholesterol",single,6,7).
+bond("24-ethylcholesterol",single,7,8). bond("24-ethylcholesterol",single,8,9). bond("24-ethylcholesterol",single,8,14).
+bond("24-ethylcholesterol",single,9,10). bond("24-ethylcholesterol",single,9,11). bond("24-ethylcholesterol",singleR,10,19).
+bond("24-ethylcholesterol",single,11,12). bond("24-ethylcholesterol",single,12,13). bond("24-ethylcholesterol",single,13,14).
+bond("24-ethylcholesterol",single,14,15). bond("24-ethylcholesterol",single,15,16). bond("24-ethylcholesterol",single,16,17).
+bond("24-ethylcholesterol",single,13,17). bond("24-ethylcholesterol",singleR,13,18). bond("24-ethylcholesterol",singleR,17,20).
+bond("24-ethylcholesterol",singleS,20,21). bond("24-ethylcholesterol",single,20,22). bond("24-ethylcholesterol",single,22,23).
+bond("24-ethylcholesterol",single,23,24). bond("24-ethylcholesterol",single,24,241). bond("24-ethylcholesterol",single,241,242).
+bond("24-ethylcholesterol",single,24,25). bond("24-ethylcholesterol",single,25,26). bond("24-ethylcholesterol",single,25,27).
 
 atom("24-methylenecholesterol",1..24,carb). atom("24-methylenecholesterol",241,carb). atom("24-methylenecholesterol",25..27,carb).
 atom("24-methylenecholesterol",31,oxyg).
@@ -55,34 +68,35 @@ bond("24-methylenecholesterol",single,23,24). bond("24-methylenecholesterol",dou
 bond("24-methylenecholesterol",single,25,26). bond("24-methylenecholesterol",single,25,27).
 
 
-atom("campesterol",1..24,carb). atom("campesterol",241,carb). atom("campesterol",25..27,carb).
-atom("campesterol",31,oxyg).
-bond("campesterol",single,1,2). bond("campesterol",single,1,10). bond("campesterol",single,2,3).
-bond("campesterol",single,3,4). bond("campesterol",singleR,3,31). bond("campesterol",single,4,5).
-bond("campesterol",double,5,6). bond("campesterol",single,5,10). bond("campesterol",single,6,7).
-bond("campesterol",single,7,8). bond("campesterol",single,8,9). bond("campesterol",single,8,14).
-bond("campesterol",single,9,10). bond("campesterol",single,9,11). bond("campesterol",singleR,10,19).
-bond("campesterol",single,11,12). bond("campesterol",single,12,13). bond("campesterol",single,13,14).
-bond("campesterol",single,14,15). bond("campesterol",single,15,16). bond("campesterol",single,16,17).
-bond("campesterol",single,13,17). bond("campesterol",singleR,13,18). bond("campesterol",singleR,17,20).
-bond("campesterol",singleS,20,21). bond("campesterol",single,20,22). bond("campesterol",single,22,23).
-bond("campesterol",single,23,24). bond("campesterol",singleR,24,241). bond("campesterol",single,24,25).
-bond("campesterol",single,25,26). bond("campesterol",single,25,27).
+atom("24-methylcholesterol",1..24,carb). atom("24-methylcholesterol",241,carb). atom("24-methylcholesterol",25..27,carb).
+atom("24-methylcholesterol",31,oxyg).
+bond("24-methylcholesterol",single,1,2). bond("24-methylcholesterol",single,1,10). bond("24-methylcholesterol",single,2,3).
+bond("24-methylcholesterol",single,3,4). bond("24-methylcholesterol",singleR,3,31). bond("24-methylcholesterol",single,4,5).
+bond("24-methylcholesterol",double,5,6). bond("24-methylcholesterol",single,5,10). bond("24-methylcholesterol",single,6,7).
+bond("24-methylcholesterol",single,7,8). bond("24-methylcholesterol",single,8,9). bond("24-methylcholesterol",single,8,14).
+bond("24-methylcholesterol",single,9,10). bond("24-methylcholesterol",single,9,11). bond("24-methylcholesterol",singleR,10,19).
+bond("24-methylcholesterol",single,11,12). bond("24-methylcholesterol",single,12,13). bond("24-methylcholesterol",single,13,14).
+bond("24-methylcholesterol",single,14,15). bond("24-methylcholesterol",single,15,16). bond("24-methylcholesterol",single,16,17).
+bond("24-methylcholesterol",single,13,17). bond("24-methylcholesterol",singleR,13,18). bond("24-methylcholesterol",singleR,17,20).
+bond("24-methylcholesterol",singleS,20,21). bond("24-methylcholesterol",single,20,22). bond("24-methylcholesterol",single,22,23).
+bond("24-methylcholesterol",single,23,24). bond("24-methylcholesterol",single,24,241). bond("24-methylcholesterol",single,24,25).
+bond("24-methylcholesterol",single,25,26). bond("24-methylcholesterol",single,25,27).
 
 
-atom("brassicasterol",1..24,carb). atom("brassicasterol",241,carb). atom("brassicasterol",25..27,carb).
-atom("brassicasterol",31,oxyg).
-bond("brassicasterol",single,1,2). bond("brassicasterol",single,1,10). bond("brassicasterol",single,2,3).
-bond("brassicasterol",single,3,4). bond("brassicasterol",singleR,3,31). bond("brassicasterol",single,4,5).
-bond("brassicasterol",double,5,6). bond("brassicasterol",single,5,10). bond("brassicasterol",single,6,7).
-bond("brassicasterol",single,7,8). bond("brassicasterol",single,8,9). bond("brassicasterol",single,8,14).
-bond("brassicasterol",single,9,10). bond("brassicasterol",single,9,11). bond("brassicasterol",singleR,10,19).
-bond("brassicasterol",single,11,12). bond("brassicasterol",single,12,13). bond("brassicasterol",single,13,14).
-bond("brassicasterol",single,14,15). bond("brassicasterol",single,15,16). bond("brassicasterol",single,16,17).
-bond("brassicasterol",single,13,17). bond("brassicasterol",singleR,13,18). bond("brassicasterol",singleR,17,20).
-bond("brassicasterol",singleS,20,21). bond("brassicasterol",single,20,22). bond("brassicasterol",double,22,23).
-bond("brassicasterol",single,23,24). bond("brassicasterol",singleR,24,241). bond("brassicasterol",single,24,25).
-bond("brassicasterol",single,25,26). bond("brassicasterol",single,25,27).
+atom("24-methylcholest-22-enol",1..24,carb). atom("24-methylcholest-22-enol",241,carb). atom("24-methylcholest-22-enol",25..27,carb).
+atom("24-methylcholest-22-enol",31,oxyg).
+bond("24-methylcholest-22-enol",single,1,2). bond("24-methylcholest-22-enol",single,1,10). bond("24-methylcholest-22-enol",single,2,3).
+bond("24-methylcholest-22-enol",single,3,4). bond("24-methylcholest-22-enol",singleR,3,31). bond("24-methylcholest-22-enol",single,4,5).
+bond("24-methylcholest-22-enol",double,5,6). bond("24-methylcholest-22-enol",single,5,10). bond("24-methylcholest-22-enol",single,6,7).
+bond("24-methylcholest-22-enol",single,7,8). bond("24-methylcholest-22-enol",single,8,9). bond("24-methylcholest-22-enol",single,8,14).
+bond("24-methylcholest-22-enol",single,9,10). bond("24-methylcholest-22-enol",single,9,11). bond("24-methylcholest-22-enol",singleR,10,19).
+bond("24-methylcholest-22-enol",single,11,12). bond("24-methylcholest-22-enol",single,12,13). bond("24-methylcholest-22-enol",single,13,14).
+bond("24-methylcholest-22-enol",single,14,15). bond("24-methylcholest-22-enol",single,15,16). bond("24-methylcholest-22-enol",single,16,17).
+bond("24-methylcholest-22-enol",single,13,17). bond("24-methylcholest-22-enol",singleR,13,18). bond("24-methylcholest-22-enol",singleR,17,20).
+bond("24-methylcholest-22-enol",singleS,20,21). bond("24-methylcholest-22-enol",single,20,22). bond("24-methylcholest-22-enol",double,22,23).
+bond("24-methylcholest-22-enol",single,23,24). bond("24-methylcholest-22-enol",single,24,241). bond("24-methylcholest-22-enol",single,24,25).
+bond("24-methylcholest-22-enol",single,25,26). bond("24-methylcholest-22-enol",single,25,27).
+
 
 
 atom("24-methylenecycloartanol",1..24,carb). atom("24-methylenecycloartanol",241,carb). atom("24-methylenecycloartanol",25..30,carb).
@@ -631,7 +645,6 @@ bond("24-methyldesmosterol",singleS,20,21). bond("24-methyldesmosterol",single,2
 bond("24-methyldesmosterol",single,23,24). bond("24-methyldesmosterol",singleR,24,241). bond("24-methyldesmosterol",double,24,25).
 bond("24-methyldesmosterol",single,25,26). bond("24-methyldesmosterol",single,25,27).
 
-
 atom("7-dehydrodesmosterol",1..27,carb). atom("7-dehydrodesmosterol",31,oxyg).
 bond("7-dehydrodesmosterol",single,1,2). bond("7-dehydrodesmosterol",single,1,10). bond("7-dehydrodesmosterol",single,2,3).
 bond("7-dehydrodesmosterol",single,3,4). bond("7-dehydrodesmosterol",singleR,3,31). bond("7-dehydrodesmosterol",single,4,5).
@@ -750,10 +763,8 @@ reaction(rxn_22198,"5-dehydroisoavenasterol","fucosterol").
 % Molecules absent in the organism.
 
 absentmolecules("ergosterol").
-absentmolecules("zymosterol").
 absentmolecules("lanosterol").
 absentmolecules("lathosterol").
-absentmolecules("sitosterol").
 
 
 % Source molecule for inference.
@@ -763,10 +774,11 @@ source("cycloartenol").
 
 % Initiation of incremental grounding.
 init(pathway("cycloartenol","cholesterol")).
-goal(pathway("cycloartenol","stigmasterol")).
+goal(pathway("cycloartenol","24-methylcholest-22-enol")).
+goal(pathway("cycloartenol","24-ethylcholest-22-enol")).
 goal(pathway("cycloartenol","fucosterol")).
 
 %* Expected inferred reactions: 
 
-reaction(c28_methylation, "brassicasterol", "stigmasterol"). 
+reaction(c28_methylation, "episterol", "isoavenasterol"). 
 *%

--- a/pathmodel/data/brown_sterols_pwy.lp
+++ b/pathmodel/data/brown_sterols_pwy.lp
@@ -414,34 +414,6 @@ bond("ergosta-5,7,24(28)-trien-3β-ol",single,25,26). bond("ergosta-5,7,24(28)-t
 
 % Sterols from PWY-8191
 
-atom("(3β,9β)-4α-demethyl-4α-methylhydroxy-9,19-cyclolanost-24-en-3-ol",1..30,carb). atom("(3β,9β)-4α-demethyl-4α-methylhydroxy-9,19-cyclolanost-24-en-3-ol",31,oxyg). atom("(3β,9β)-4α-demethyl-4α-methylhydroxy-9,19-cyclolanost-24-en-3-ol",33,oxyg).
-bond("(3β,9β)-4α-demethyl-4α-methylhydroxy-9,19-cyclolanost-24-en-3-ol",single,1,2). bond("(3β,9β)-4α-demethyl-4α-methylhydroxy-9,19-cyclolanost-24-en-3-ol",single,1,10). bond("(3β,9β)-4α-demethyl-4α-methylhydroxy-9,19-cyclolanost-24-en-3-ol",single,2,3).
-bond("(3β,9β)-4α-demethyl-4α-methylhydroxy-9,19-cyclolanost-24-en-3-ol",single,3,4). bond("(3β,9β)-4α-demethyl-4α-methylhydroxy-9,19-cyclolanost-24-en-3-ol",singleR,3,31). bond("(3β,9β)-4α-demethyl-4α-methylhydroxy-9,19-cyclolanost-24-en-3-ol",single,4,5).
-bond("(3β,9β)-4α-demethyl-4α-methylhydroxy-9,19-cyclolanost-24-en-3-ol",singleR,4,29). bond("(3β,9β)-4α-demethyl-4α-methylhydroxy-9,19-cyclolanost-24-en-3-ol",singleS,4,28). bond("(3β,9β)-4α-demethyl-4α-methylhydroxy-9,19-cyclolanost-24-en-3-ol",single,5,6).
-bond("(3β,9β)-4α-demethyl-4α-methylhydroxy-9,19-cyclolanost-24-en-3-ol",single,5,10). bond("(3β,9β)-4α-demethyl-4α-methylhydroxy-9,19-cyclolanost-24-en-3-ol",single,6,7). bond("(3β,9β)-4α-demethyl-4α-methylhydroxy-9,19-cyclolanost-24-en-3-ol",single,7,8).
-bond("(3β,9β)-4α-demethyl-4α-methylhydroxy-9,19-cyclolanost-24-en-3-ol",single,8,9). bond("(3β,9β)-4α-demethyl-4α-methylhydroxy-9,19-cyclolanost-24-en-3-ol",single,8,14). bond("(3β,9β)-4α-demethyl-4α-methylhydroxy-9,19-cyclolanost-24-en-3-ol",single,9,10).
-bond("(3β,9β)-4α-demethyl-4α-methylhydroxy-9,19-cyclolanost-24-en-3-ol",single,9,11).bond("(3β,9β)-4α-demethyl-4α-methylhydroxy-9,19-cyclolanost-24-en-3-ol",singleR,9,19). bond("(3β,9β)-4α-demethyl-4α-methylhydroxy-9,19-cyclolanost-24-en-3-ol",singleR,10,19).
-bond("(3β,9β)-4α-demethyl-4α-methylhydroxy-9,19-cyclolanost-24-en-3-ol",single,11,12). bond("(3β,9β)-4α-demethyl-4α-methylhydroxy-9,19-cyclolanost-24-en-3-ol",single,12,13). bond("(3β,9β)-4α-demethyl-4α-methylhydroxy-9,19-cyclolanost-24-en-3-ol",single,13,14).
-bond("(3β,9β)-4α-demethyl-4α-methylhydroxy-9,19-cyclolanost-24-en-3-ol",single,14,15). bond("(3β,9β)-4α-demethyl-4α-methylhydroxy-9,19-cyclolanost-24-en-3-ol",singleS,14,30). bond("(3β,9β)-4α-demethyl-4α-methylhydroxy-9,19-cyclolanost-24-en-3-ol",single,15,16).
-bond("(3β,9β)-4α-demethyl-4α-methylhydroxy-9,19-cyclolanost-24-en-3-ol",single,16,17). bond("(3β,9β)-4α-demethyl-4α-methylhydroxy-9,19-cyclolanost-24-en-3-ol",single,13,17). bond("(3β,9β)-4α-demethyl-4α-methylhydroxy-9,19-cyclolanost-24-en-3-ol",singleR,13,18).
-bond("(3β,9β)-4α-demethyl-4α-methylhydroxy-9,19-cyclolanost-24-en-3-ol",singleR,17,20). bond("(3β,9β)-4α-demethyl-4α-methylhydroxy-9,19-cyclolanost-24-en-3-ol",singleS,20,21). bond("(3β,9β)-4α-demethyl-4α-methylhydroxy-9,19-cyclolanost-24-en-3-ol",single,20,22).
-bond("(3β,9β)-4α-demethyl-4α-methylhydroxy-9,19-cyclolanost-24-en-3-ol",single,22,23). bond("(3β,9β)-4α-demethyl-4α-methylhydroxy-9,19-cyclolanost-24-en-3-ol",single,23,24). bond("(3β,9β)-4α-demethyl-4α-methylhydroxy-9,19-cyclolanost-24-en-3-ol",double,24,25).
-bond("(3β,9β)-4α-demethyl-4α-methylhydroxy-9,19-cyclolanost-24-en-3-ol",single,25,26). bond("(3β,9β)-4α-demethyl-4α-methylhydroxy-9,19-cyclolanost-24-en-3-ol",single,25,27). bond("(3β,9β)-4α-demethyl-4α-methylhydroxy-9,19-cyclolanost-24-en-3-ol",single,29,33).
-
-atom("(3β,9β)-4α-demethyl-4α-formyl-9,19-cyclolanost-24-en-3-ol",1..30,carb). atom("(3β,9β)-4α-demethyl-4α-formyl-9,19-cyclolanost-24-en-3-ol",31,oxyg). atom("(3β,9β)-4α-demethyl-4α-formyl-9,19-cyclolanost-24-en-3-ol",33,oxyg).
-bond("(3β,9β)-4α-demethyl-4α-formyl-9,19-cyclolanost-24-en-3-ol",single,1,2). bond("(3β,9β)-4α-demethyl-4α-formyl-9,19-cyclolanost-24-en-3-ol",single,1,10). bond("(3β,9β)-4α-demethyl-4α-formyl-9,19-cyclolanost-24-en-3-ol",single,2,3).
-bond("(3β,9β)-4α-demethyl-4α-formyl-9,19-cyclolanost-24-en-3-ol",single,3,4). bond("(3β,9β)-4α-demethyl-4α-formyl-9,19-cyclolanost-24-en-3-ol",singleR,3,31). bond("(3β,9β)-4α-demethyl-4α-formyl-9,19-cyclolanost-24-en-3-ol",single,4,5).
-bond("(3β,9β)-4α-demethyl-4α-formyl-9,19-cyclolanost-24-en-3-ol",singleR,4,29). bond("(3β,9β)-4α-demethyl-4α-formyl-9,19-cyclolanost-24-en-3-ol",singleS,4,28). bond("(3β,9β)-4α-demethyl-4α-formyl-9,19-cyclolanost-24-en-3-ol",single,5,6).
-bond("(3β,9β)-4α-demethyl-4α-formyl-9,19-cyclolanost-24-en-3-ol",single,5,10). bond("(3β,9β)-4α-demethyl-4α-formyl-9,19-cyclolanost-24-en-3-ol",single,6,7). bond("(3β,9β)-4α-demethyl-4α-formyl-9,19-cyclolanost-24-en-3-ol",single,7,8).
-bond("(3β,9β)-4α-demethyl-4α-formyl-9,19-cyclolanost-24-en-3-ol",single,8,9). bond("(3β,9β)-4α-demethyl-4α-formyl-9,19-cyclolanost-24-en-3-ol",single,8,14). bond("(3β,9β)-4α-demethyl-4α-formyl-9,19-cyclolanost-24-en-3-ol",single,9,10).
-bond("(3β,9β)-4α-demethyl-4α-formyl-9,19-cyclolanost-24-en-3-ol",single,9,11).bond("(3β,9β)-4α-demethyl-4α-formyl-9,19-cyclolanost-24-en-3-ol",singleR,9,19). bond("(3β,9β)-4α-demethyl-4α-formyl-9,19-cyclolanost-24-en-3-ol",singleR,10,19).
-bond("(3β,9β)-4α-demethyl-4α-formyl-9,19-cyclolanost-24-en-3-ol",single,11,12). bond("(3β,9β)-4α-demethyl-4α-formyl-9,19-cyclolanost-24-en-3-ol",single,12,13). bond("(3β,9β)-4α-demethyl-4α-formyl-9,19-cyclolanost-24-en-3-ol",single,13,14).
-bond("(3β,9β)-4α-demethyl-4α-formyl-9,19-cyclolanost-24-en-3-ol",single,14,15). bond("(3β,9β)-4α-demethyl-4α-formyl-9,19-cyclolanost-24-en-3-ol",singleS,14,30). bond("(3β,9β)-4α-demethyl-4α-formyl-9,19-cyclolanost-24-en-3-ol",single,15,16).
-bond("(3β,9β)-4α-demethyl-4α-formyl-9,19-cyclolanost-24-en-3-ol",single,16,17). bond("(3β,9β)-4α-demethyl-4α-formyl-9,19-cyclolanost-24-en-3-ol",single,13,17). bond("(3β,9β)-4α-demethyl-4α-formyl-9,19-cyclolanost-24-en-3-ol",singleR,13,18).
-bond("(3β,9β)-4α-demethyl-4α-formyl-9,19-cyclolanost-24-en-3-ol",singleR,17,20). bond("(3β,9β)-4α-demethyl-4α-formyl-9,19-cyclolanost-24-en-3-ol",singleS,20,21). bond("(3β,9β)-4α-demethyl-4α-formyl-9,19-cyclolanost-24-en-3-ol",single,20,22).
-bond("(3β,9β)-4α-demethyl-4α-formyl-9,19-cyclolanost-24-en-3-ol",single,22,23). bond("(3β,9β)-4α-demethyl-4α-formyl-9,19-cyclolanost-24-en-3-ol",single,23,24). bond("(3β,9β)-4α-demethyl-4α-formyl-9,19-cyclolanost-24-en-3-ol",double,24,25).
-bond("(3β,9β)-4α-demethyl-4α-formyl-9,19-cyclolanost-24-en-3-ol",single,25,26). bond("(3β,9β)-4α-demethyl-4α-formyl-9,19-cyclolanost-24-en-3-ol",single,25,27). bond("(3β,9β)-4α-demethyl-4α-formyl-9,19-cyclolanost-24-en-3-ol",double,29,33).
-
 atom("(3β,9β)-4α-demethyl-4α-carboxy-9,19-cyclolanost-24-en-3-ol",1..30,carb). atom("(3β,9β)-4α-demethyl-4α-carboxy-9,19-cyclolanost-24-en-3-ol",31..33,oxyg).
 bond("(3β,9β)-4α-demethyl-4α-carboxy-9,19-cyclolanost-24-en-3-ol",single,1,2). bond("(3β,9β)-4α-demethyl-4α-carboxy-9,19-cyclolanost-24-en-3-ol",single,1,10). bond("(3β,9β)-4α-demethyl-4α-carboxy-9,19-cyclolanost-24-en-3-ol",single,2,3).
 bond("(3β,9β)-4α-demethyl-4α-carboxy-9,19-cyclolanost-24-en-3-ol",single,3,4). bond("(3β,9β)-4α-demethyl-4α-carboxy-9,19-cyclolanost-24-en-3-ol",singleR,3,31). bond("(3β,9β)-4α-demethyl-4α-carboxy-9,19-cyclolanost-24-en-3-ol",single,4,5).
@@ -712,20 +684,14 @@ reaction(Reaction type (name), Compound 1 [, Active site atom number], [Compound
 
 % Reactions from PWY-8191: cholesterol biosynthesis (algae, late side-chain reductase) 
 
-reaction(rxn_21826, "cycloartenol","(3β,9β)-4α-demethyl-4α-methylhydroxy-9,19-cyclolanost-24-en-3-ol").
-reaction(rxn_21827, "(3β,9β)-4α-demethyl-4α-methylhydroxy-9,19-cyclolanost-24-en-3-ol", "(3β,9β)-4α-demethyl-4α-formyl-9,19-cyclolanost-24-en-3-ol").
-reaction(rxn_21828, "(3β,9β)-4α-demethyl-4α-formyl-9,19-cyclolanost-24-en-3-ol", "(3β,9β)-4α-demethyl-4α-carboxy-9,19-cyclolanost-24-en-3-ol").
+reaction(rxn_21829, "cycloartenol", "(3β,9β)-4α-demethyl-4α-carboxy-9,19-cyclolanost-24-en-3-ol").
 reaction(rxn_21830, "(3β,9β)-4α-demethyl-4α-carboxy-9,19-cyclolanost-24-en-3-ol", "31-norcycloartenone").
 reaction(rxn_21831, "31-norcycloartenone", "31-norcycloartenol").
 reaction(rxn_11876, "31-norcycloartenol", "4α,14α-dimethyl-5α-cholesta-8,24-dien-3β-ol").
-reaction(rxn_21165, "4α,14α-dimethyl-5α-cholesta-8,24-dien-3β-ol", "4α-hydroxymethyl-14α-methyl-5α-cholesta-8,24-dien-3β-ol").
-reaction(rxn_21166, "4α-hydroxymethyl-14α-methyl-5α-cholesta-8,24-dien-3β-ol", "4α-formyl-14α-methyl-5α-cholesta-8,24-dien-3β-ol").
-reaction(rxn_21167, "4α-formyl-14α-methyl-5α-cholesta-8,24-dien-3β-ol", "4α-methyl-5α-cholesta-8,14,24-trien-3β-ol").
+reaction(rxn_11881, "4α,14α-dimethyl-5α-cholesta-8,24-dien-3β-ol", "4α-methyl-5α-cholesta-8,14,24-trien-3β-ol").
 reaction(rxn_11878, "4α-methyl-5α-cholesta-8,14,24-trien-3β-ol", "4α-methyl-5α-cholesta-8,24-dien-3β-ol").
 reaction(rxn_11884, "4α-methyl-5α-cholesta-8,24-dien-3β-ol", "4α-methyl-5α-cholesta-7,24-dien-3β-ol").
-reaction(rxn_21833, "4α-methyl-5α-cholesta-7,24-dien-3β-ol", "4α-methylhydroxy-5α-cholest-7,24-dien-3β-ol").
-reaction(rxn_21834, "4α-methylhydroxy-5α-cholest-7,24-dien-3β-ol", "4α-formyl-5α-cholest-7,24-dien-3β-ol").
-reaction(rxn_21835, "4α-formyl-5α-cholest-7,24-dien-3β-ol", "4α-carboxy-5α-cholesta-7,24-dien-3β-ol").
+reaction(rxn_21836, "4α-methyl-5α-cholesta-7,24-dien-3β-ol", "4α-carboxy-5α-cholesta-7,24-dien-3β-ol").
 reaction(rxn_11959, "4α-carboxy-5α-cholesta-7,24-dien-3β-ol", "5α-cholesta-7,24-dien-3-one").
 reaction(rxn_21837, "5α-cholesta-7,24-dien-3-one", "5α-cholesta-7,24-dienol").
 reaction(rxn_11887, "5α-cholesta-7,24-dienol", "7-dehydrodesmosterol").
@@ -745,14 +711,6 @@ reaction(cycloeucalenol_cycloisomerase_rxn,"cycloeucalenol","obtusifoliol").
 reaction(obtusifoliol_demethylase,"obtusifoliol","4α-methyl-5α-ergosta-8,14,24(28)-trien-3β-ol").
 reaction(rxn_4144,"4α-methyl-5α-ergosta-8,14,24(28)-trien-3β-ol","4α-methyl-5α-ergosta-8,24-dien-3β-ol").
 reaction(rxn_4161,"4α-methyl-5α-ergosta-8,24-dien-3β-ol","24-methylenelophenol").
-reaction(c24_methyltransferase,"24-methylenelophenol","24-ethylidenelophenol").
-reaction(rxn_11935,"24-ethylidenelophenol","4α-hydroxymethyl-stigmasta-7,24(241)-dien-3β-ol").
-reaction(rxn_11936,"4α-hydroxymethyl-stigmasta-7,24(241)-dien-3β-ol","4α-formyl-stigmasta-7,24(241)-dien-3β-ol").
-reaction(rxn_11937,"4α-formyl-stigmasta-7,24(241)-dien-3β-ol","4α-carboxy-stigmasta-7,24(241)-dien-3β-ol").
-reaction(rxn_11938,"4α-carboxy-stigmasta-7,24(241)-dien-3β-ol","avenastenone").
-reaction(rxn_11939,"avenastenone","avenasterol").
-reaction(rxn_4209,"avenasterol","5-dehydroavenasterol").
-reaction(rxn_4210,"5-dehydroavenasterol","fucosterol").
 reaction(rxn_11930,"24-methylenelophenol","4α-hydroxymethyl-ergosta-7,24(241)-dien-3β-ol").
 reaction(rxn_11931,"4α-hydroxymethyl-ergosta-7,24(241)-dien-3β-ol","4α-formyl-ergosta-7,24(241)-dien-3β-ol").
 reaction(rxn_11932,"4α-formyl-ergosta-7,24(241)-dien-3β-ol","4α-carboxy-ergosta-7,24(241)-dien-3β-ol").

--- a/pathmodel/data/brown_sterols_pwy.lp
+++ b/pathmodel/data/brown_sterols_pwy.lp
@@ -51,7 +51,7 @@ bond("24-methylenecholesterol",single,11,12). bond("24-methylenecholesterol",sin
 bond("24-methylenecholesterol",single,14,15). bond("24-methylenecholesterol",single,15,16). bond("24-methylenecholesterol",single,16,17).
 bond("24-methylenecholesterol",single,13,17). bond("24-methylenecholesterol",singleR,13,18). bond("24-methylenecholesterol",singleR,17,20).
 bond("24-methylenecholesterol",singleS,20,21). bond("24-methylenecholesterol",single,20,22). bond("24-methylenecholesterol",single,22,23).
-bond("24-methylenecholesterol",single,23,24). bond("24-methylenecholesterol",doubleE,24,241). bond("24-methylenecholesterol",single,24,25).
+bond("24-methylenecholesterol",single,23,24). bond("24-methylenecholesterol",double,24,241). bond("24-methylenecholesterol",single,24,25).
 bond("24-methylenecholesterol",single,25,26). bond("24-methylenecholesterol",single,25,27).
 
 
@@ -97,7 +97,7 @@ bond("24-methylenecycloartanol",single,11,12). bond("24-methylenecycloartanol",s
 bond("24-methylenecycloartanol",single,14,15). bond("24-methylenecycloartanol",singleS,14,30). bond("24-methylenecycloartanol",single,15,16).
 bond("24-methylenecycloartanol",single,16,17). bond("24-methylenecycloartanol",single,13,17). bond("24-methylenecycloartanol",singleR,13,18).
 bond("24-methylenecycloartanol",singleR,17,20). bond("24-methylenecycloartanol",singleS,20,21). bond("24-methylenecycloartanol",single,20,22).
-bond("24-methylenecycloartanol",single,22,23). bond("24-methylenecycloartanol",single,23,24). bond("24-methylenecycloartanol",doubleE,24,241).
+bond("24-methylenecycloartanol",single,22,23). bond("24-methylenecycloartanol",single,23,24). bond("24-methylenecycloartanol",double,24,241).
 bond("24-methylenecycloartanol",single,24,25). bond("24-methylenecycloartanol",single,25,26). bond("24-methylenecycloartanol",single,25,27).
 
 atom("4α-hydroxymethyl,4β,14α-dimethyl-9β,19-cyclo-5α-ergost-24(241)-en-3β-ol",1..24,carb). atom("4α-hydroxymethyl,4β,14α-dimethyl-9β,19-cyclo-5α-ergost-24(241)-en-3β-ol",241,carb). atom("4α-hydroxymethyl,4β,14α-dimethyl-9β,19-cyclo-5α-ergost-24(241)-en-3β-ol",25..30,carb).
@@ -112,7 +112,7 @@ bond("4α-hydroxymethyl,4β,14α-dimethyl-9β,19-cyclo-5α-ergost-24(241)-en-3β
 bond("4α-hydroxymethyl,4β,14α-dimethyl-9β,19-cyclo-5α-ergost-24(241)-en-3β-ol",single,14,15). bond("4α-hydroxymethyl,4β,14α-dimethyl-9β,19-cyclo-5α-ergost-24(241)-en-3β-ol",singleS,14,30). bond("4α-hydroxymethyl,4β,14α-dimethyl-9β,19-cyclo-5α-ergost-24(241)-en-3β-ol",single,15,16).
 bond("4α-hydroxymethyl,4β,14α-dimethyl-9β,19-cyclo-5α-ergost-24(241)-en-3β-ol",single,16,17). bond("4α-hydroxymethyl,4β,14α-dimethyl-9β,19-cyclo-5α-ergost-24(241)-en-3β-ol",single,13,17). bond("4α-hydroxymethyl,4β,14α-dimethyl-9β,19-cyclo-5α-ergost-24(241)-en-3β-ol",singleR,13,18).
 bond("4α-hydroxymethyl,4β,14α-dimethyl-9β,19-cyclo-5α-ergost-24(241)-en-3β-ol",singleR,17,20). bond("4α-hydroxymethyl,4β,14α-dimethyl-9β,19-cyclo-5α-ergost-24(241)-en-3β-ol",singleS,20,21). bond("4α-hydroxymethyl,4β,14α-dimethyl-9β,19-cyclo-5α-ergost-24(241)-en-3β-ol",single,20,22).
-bond("4α-hydroxymethyl,4β,14α-dimethyl-9β,19-cyclo-5α-ergost-24(241)-en-3β-ol",single,22,23). bond("4α-hydroxymethyl,4β,14α-dimethyl-9β,19-cyclo-5α-ergost-24(241)-en-3β-ol",single,23,24). bond("4α-hydroxymethyl,4β,14α-dimethyl-9β,19-cyclo-5α-ergost-24(241)-en-3β-ol",doubleE,24,241).
+bond("4α-hydroxymethyl,4β,14α-dimethyl-9β,19-cyclo-5α-ergost-24(241)-en-3β-ol",single,22,23). bond("4α-hydroxymethyl,4β,14α-dimethyl-9β,19-cyclo-5α-ergost-24(241)-en-3β-ol",single,23,24). bond("4α-hydroxymethyl,4β,14α-dimethyl-9β,19-cyclo-5α-ergost-24(241)-en-3β-ol",double,24,241).
 bond("4α-hydroxymethyl,4β,14α-dimethyl-9β,19-cyclo-5α-ergost-24(241)-en-3β-ol",single,24,25). bond("4α-hydroxymethyl,4β,14α-dimethyl-9β,19-cyclo-5α-ergost-24(241)-en-3β-ol",single,25,26). bond("4α-hydroxymethyl,4β,14α-dimethyl-9β,19-cyclo-5α-ergost-24(241)-en-3β-ol",single,25,27).
 bond("4α-hydroxymethyl,4β,14α-dimethyl-9β,19-cyclo-5α-ergost-24(241)-en-3β-ol",single,28,32).
 
@@ -128,7 +128,7 @@ bond("4α-formyl,4β,14α-dimethyl-9β,19-cyclo-5α-ergost-24(241)-en-3β-ol",si
 bond("4α-formyl,4β,14α-dimethyl-9β,19-cyclo-5α-ergost-24(241)-en-3β-ol",single,14,15). bond("4α-formyl,4β,14α-dimethyl-9β,19-cyclo-5α-ergost-24(241)-en-3β-ol",singleS,14,30). bond("4α-formyl,4β,14α-dimethyl-9β,19-cyclo-5α-ergost-24(241)-en-3β-ol",single,15,16).
 bond("4α-formyl,4β,14α-dimethyl-9β,19-cyclo-5α-ergost-24(241)-en-3β-ol",single,16,17). bond("4α-formyl,4β,14α-dimethyl-9β,19-cyclo-5α-ergost-24(241)-en-3β-ol",single,13,17). bond("4α-formyl,4β,14α-dimethyl-9β,19-cyclo-5α-ergost-24(241)-en-3β-ol",singleR,13,18).
 bond("4α-formyl,4β,14α-dimethyl-9β,19-cyclo-5α-ergost-24(241)-en-3β-ol",singleR,17,20). bond("4α-formyl,4β,14α-dimethyl-9β,19-cyclo-5α-ergost-24(241)-en-3β-ol",singleS,20,21). bond("4α-formyl,4β,14α-dimethyl-9β,19-cyclo-5α-ergost-24(241)-en-3β-ol",single,20,22).
-bond("4α-formyl,4β,14α-dimethyl-9β,19-cyclo-5α-ergost-24(241)-en-3β-ol",single,22,23). bond("4α-formyl,4β,14α-dimethyl-9β,19-cyclo-5α-ergost-24(241)-en-3β-ol",single,23,24). bond("4α-formyl,4β,14α-dimethyl-9β,19-cyclo-5α-ergost-24(241)-en-3β-ol",doubleE,24,241).
+bond("4α-formyl,4β,14α-dimethyl-9β,19-cyclo-5α-ergost-24(241)-en-3β-ol",single,22,23). bond("4α-formyl,4β,14α-dimethyl-9β,19-cyclo-5α-ergost-24(241)-en-3β-ol",single,23,24). bond("4α-formyl,4β,14α-dimethyl-9β,19-cyclo-5α-ergost-24(241)-en-3β-ol",double,24,241).
 bond("4α-formyl,4β,14α-dimethyl-9β,19-cyclo-5α-ergost-24(241)-en-3β-ol",single,24,25). bond("4α-formyl,4β,14α-dimethyl-9β,19-cyclo-5α-ergost-24(241)-en-3β-ol",single,25,26). bond("4α-formyl,4β,14α-dimethyl-9β,19-cyclo-5α-ergost-24(241)-en-3β-ol",single,25,27).
 bond("4α-formyl,4β,14α-dimethyl-9β,19-cyclo-5α-ergost-24(241)-en-3β-ol",double,28,32).
 
@@ -144,7 +144,7 @@ bond("4α-carboxy-4β,14α-dimethyl-9β,19-cyclo-5α-ergost-24(241)-en-3β-ol",s
 bond("4α-carboxy-4β,14α-dimethyl-9β,19-cyclo-5α-ergost-24(241)-en-3β-ol",single,14,15). bond("4α-carboxy-4β,14α-dimethyl-9β,19-cyclo-5α-ergost-24(241)-en-3β-ol",singleS,14,30). bond("4α-carboxy-4β,14α-dimethyl-9β,19-cyclo-5α-ergost-24(241)-en-3β-ol",single,15,16).
 bond("4α-carboxy-4β,14α-dimethyl-9β,19-cyclo-5α-ergost-24(241)-en-3β-ol",single,16,17). bond("4α-carboxy-4β,14α-dimethyl-9β,19-cyclo-5α-ergost-24(241)-en-3β-ol",single,13,17). bond("4α-carboxy-4β,14α-dimethyl-9β,19-cyclo-5α-ergost-24(241)-en-3β-ol",singleR,13,18).
 bond("4α-carboxy-4β,14α-dimethyl-9β,19-cyclo-5α-ergost-24(241)-en-3β-ol",singleR,17,20). bond("4α-carboxy-4β,14α-dimethyl-9β,19-cyclo-5α-ergost-24(241)-en-3β-ol",singleS,20,21). bond("4α-carboxy-4β,14α-dimethyl-9β,19-cyclo-5α-ergost-24(241)-en-3β-ol",single,20,22).
-bond("4α-carboxy-4β,14α-dimethyl-9β,19-cyclo-5α-ergost-24(241)-en-3β-ol",single,22,23). bond("4α-carboxy-4β,14α-dimethyl-9β,19-cyclo-5α-ergost-24(241)-en-3β-ol",single,23,24). bond("4α-carboxy-4β,14α-dimethyl-9β,19-cyclo-5α-ergost-24(241)-en-3β-ol",doubleE,24,241).
+bond("4α-carboxy-4β,14α-dimethyl-9β,19-cyclo-5α-ergost-24(241)-en-3β-ol",single,22,23). bond("4α-carboxy-4β,14α-dimethyl-9β,19-cyclo-5α-ergost-24(241)-en-3β-ol",single,23,24). bond("4α-carboxy-4β,14α-dimethyl-9β,19-cyclo-5α-ergost-24(241)-en-3β-ol",double,24,241).
 bond("4α-carboxy-4β,14α-dimethyl-9β,19-cyclo-5α-ergost-24(241)-en-3β-ol",single,24,25). bond("4α-carboxy-4β,14α-dimethyl-9β,19-cyclo-5α-ergost-24(241)-en-3β-ol",single,25,26). bond("4α-carboxy-4β,14α-dimethyl-9β,19-cyclo-5α-ergost-24(241)-en-3β-ol",single,25,27).
 bond("4α-carboxy-4β,14α-dimethyl-9β,19-cyclo-5α-ergost-24(241)-en-3β-ol",double,28,32). bond("4α-carboxy-4β,14α-dimethyl-9β,19-cyclo-5α-ergost-24(241)-en-3β-ol",single,28,33).
 
@@ -160,7 +160,7 @@ bond("cycloeucalenone",single,12,13). bond("cycloeucalenone",single,13,14). bond
 bond("cycloeucalenone",singleS,14,30). bond("cycloeucalenone",single,15,16). bond("cycloeucalenone",single,16,17).
 bond("cycloeucalenone",single,13,17). bond("cycloeucalenone",singleR,13,18). bond("cycloeucalenone",singleR,17,20).
 bond("cycloeucalenone",singleS,20,21). bond("cycloeucalenone",single,20,22). bond("cycloeucalenone",single,22,23).
-bond("cycloeucalenone",single,23,24). bond("cycloeucalenone",doubleE,24,241). bond("cycloeucalenone",single,24,25).
+bond("cycloeucalenone",single,23,24). bond("cycloeucalenone",double,24,241). bond("cycloeucalenone",single,24,25).
 bond("cycloeucalenone",single,25,26). bond("cycloeucalenone",single,25,27).
 
 atom("cycloeucalenol",1..24,carb). atom("cycloeucalenol",241,carb). atom("cycloeucalenol",25..28,carb).
@@ -175,7 +175,7 @@ bond("cycloeucalenol",single,12,13). bond("cycloeucalenol",single,13,14). bond("
 bond("cycloeucalenol",singleS,14,30). bond("cycloeucalenol",single,15,16). bond("cycloeucalenol",single,16,17).
 bond("cycloeucalenol",single,13,17). bond("cycloeucalenol",singleR,13,18). bond("cycloeucalenol",singleR,17,20).
 bond("cycloeucalenol",singleS,20,21). bond("cycloeucalenol",single,20,22). bond("cycloeucalenol",single,22,23).
-bond("cycloeucalenol",single,23,24). bond("cycloeucalenol",doubleE,24,241). bond("cycloeucalenol",single,24,25).
+bond("cycloeucalenol",single,23,24). bond("cycloeucalenol",double,24,241). bond("cycloeucalenol",single,24,25).
 bond("cycloeucalenol",single,25,26). bond("cycloeucalenol",single,25,27).
 
 atom("obtusifoliol",1..24,carb). atom("obtusifoliol",241,carb). atom("obtusifoliol",25..28,carb).
@@ -190,7 +190,7 @@ bond("obtusifoliol",single,13,14). bond("obtusifoliol",single,14,15). bond("obtu
 bond("obtusifoliol",single,15,16). bond("obtusifoliol",single,16,17). bond("obtusifoliol",single,13,17).
 bond("obtusifoliol",singleR,13,18). bond("obtusifoliol",singleR,17,20). bond("obtusifoliol",singleS,20,21).
 bond("obtusifoliol",single,20,22). bond("obtusifoliol",single,22,23). bond("obtusifoliol",single,23,24).
-bond("obtusifoliol",doubleE,24,241). bond("obtusifoliol",single,24,25). bond("obtusifoliol",single,25,26).
+bond("obtusifoliol",double,24,241). bond("obtusifoliol",single,24,25). bond("obtusifoliol",single,25,26).
 bond("obtusifoliol",single,25,27).
 
 atom("4α-methyl-5α-ergosta-8,14,24(28)-trien-3β-ol",1..24,carb). atom("4α-methyl-5α-ergosta-8,14,24(28)-trien-3β-ol",241,carb). atom("4α-methyl-5α-ergosta-8,14,24(28)-trien-3β-ol",25..28,carb).
@@ -204,7 +204,7 @@ bond("4α-methyl-5α-ergosta-8,14,24(28)-trien-3β-ol",singleR,10,19). bond("4α
 bond("4α-methyl-5α-ergosta-8,14,24(28)-trien-3β-ol",single,13,14). bond("4α-methyl-5α-ergosta-8,14,24(28)-trien-3β-ol",double,14,15). bond("4α-methyl-5α-ergosta-8,14,24(28)-trien-3β-ol",single,15,16).
 bond("4α-methyl-5α-ergosta-8,14,24(28)-trien-3β-ol",single,16,17). bond("4α-methyl-5α-ergosta-8,14,24(28)-trien-3β-ol",single,13,17). bond("4α-methyl-5α-ergosta-8,14,24(28)-trien-3β-ol",singleR,13,18).
 bond("4α-methyl-5α-ergosta-8,14,24(28)-trien-3β-ol",singleR,17,20). bond("4α-methyl-5α-ergosta-8,14,24(28)-trien-3β-ol",singleS,20,21). bond("4α-methyl-5α-ergosta-8,14,24(28)-trien-3β-ol",single,20,22).
-bond("4α-methyl-5α-ergosta-8,14,24(28)-trien-3β-ol",single,22,23). bond("4α-methyl-5α-ergosta-8,14,24(28)-trien-3β-ol",single,23,24). bond("4α-methyl-5α-ergosta-8,14,24(28)-trien-3β-ol",doubleE,24,241).
+bond("4α-methyl-5α-ergosta-8,14,24(28)-trien-3β-ol",single,22,23). bond("4α-methyl-5α-ergosta-8,14,24(28)-trien-3β-ol",single,23,24). bond("4α-methyl-5α-ergosta-8,14,24(28)-trien-3β-ol",double,24,241).
 bond("4α-methyl-5α-ergosta-8,14,24(28)-trien-3β-ol",single,24,25). bond("4α-methyl-5α-ergosta-8,14,24(28)-trien-3β-ol",single,25,26). bond("4α-methyl-5α-ergosta-8,14,24(28)-trien-3β-ol",single,25,27).
 
 atom("4α-methyl-5α-ergosta-8,24-dien-3β-ol",1..24,carb). atom("4α-methyl-5α-ergosta-8,24-dien-3β-ol",241,carb). atom("4α-methyl-5α-ergosta-8,24-dien-3β-ol",25..28,carb).
@@ -218,7 +218,7 @@ bond("4α-methyl-5α-ergosta-8,24-dien-3β-ol",singleR,10,19). bond("4α-methyl-
 bond("4α-methyl-5α-ergosta-8,24-dien-3β-ol",single,13,14). bond("4α-methyl-5α-ergosta-8,24-dien-3β-ol",single,14,15). bond("4α-methyl-5α-ergosta-8,24-dien-3β-ol",single,15,16).
 bond("4α-methyl-5α-ergosta-8,24-dien-3β-ol",single,16,17). bond("4α-methyl-5α-ergosta-8,24-dien-3β-ol",single,13,17). bond("4α-methyl-5α-ergosta-8,24-dien-3β-ol",singleR,13,18).
 bond("4α-methyl-5α-ergosta-8,24-dien-3β-ol",singleR,17,20). bond("4α-methyl-5α-ergosta-8,24-dien-3β-ol",singleS,20,21). bond("4α-methyl-5α-ergosta-8,24-dien-3β-ol",single,20,22).
-bond("4α-methyl-5α-ergosta-8,24-dien-3β-ol",single,22,23). bond("4α-methyl-5α-ergosta-8,24-dien-3β-ol",single,23,24). bond("4α-methyl-5α-ergosta-8,24-dien-3β-ol",doubleE,24,241).
+bond("4α-methyl-5α-ergosta-8,24-dien-3β-ol",single,22,23). bond("4α-methyl-5α-ergosta-8,24-dien-3β-ol",single,23,24). bond("4α-methyl-5α-ergosta-8,24-dien-3β-ol",double,24,241).
 bond("4α-methyl-5α-ergosta-8,24-dien-3β-ol",single,24,25). bond("4α-methyl-5α-ergosta-8,24-dien-3β-ol",single,25,26). bond("4α-methyl-5α-ergosta-8,24-dien-3β-ol",single,25,27).
 
 atom("24-methylenelophenol",1..24,carb). atom("24-methylenelophenol",241,carb). atom("24-methylenelophenol",25..28,carb).
@@ -232,8 +232,23 @@ bond("24-methylenelophenol",singleR,10,19). bond("24-methylenelophenol",single,1
 bond("24-methylenelophenol",single,13,14). bond("24-methylenelophenol",single,14,15). bond("24-methylenelophenol",single,15,16).
 bond("24-methylenelophenol",single,16,17). bond("24-methylenelophenol",single,13,17). bond("24-methylenelophenol",singleR,13,18).
 bond("24-methylenelophenol",singleR,17,20). bond("24-methylenelophenol",singleS,20,21). bond("24-methylenelophenol",single,20,22).
-bond("24-methylenelophenol",single,22,23). bond("24-methylenelophenol",single,23,24). bond("24-methylenelophenol",doubleE,24,241).
+bond("24-methylenelophenol",single,22,23). bond("24-methylenelophenol",single,23,24). bond("24-methylenelophenol",double,24,241).
 bond("24-methylenelophenol",single,24,25). bond("24-methylenelophenol",single,25,26). bond("24-methylenelophenol",single,25,27).
+
+atom("24-ethylidenelophenol",1..24,carb). atom("24-ethylidenelophenol",241,carb). atom("24-ethylidenelophenol",242,carb).
+atom("24-ethylidenelophenol",25..28,carb). atom("24-ethylidenelophenol",31,oxyg).
+bond("24-ethylidenelophenol",single,1,2). bond("24-ethylidenelophenol",single,1,10). bond("24-ethylidenelophenol",single,2,3).
+bond("24-ethylidenelophenol",single,3,4). bond("24-ethylidenelophenol",singleR,3,31). bond("24-ethylidenelophenol",single,4,5).
+bond("24-ethylidenelophenol",singleS,4,28). bond("24-ethylidenelophenol",single,5,6). bond("24-ethylidenelophenol",single,5,10).
+bond("24-ethylidenelophenol",single,6,7). bond("24-ethylidenelophenol",double,7,8). bond("24-ethylidenelophenol",single,8,9).
+bond("24-ethylidenelophenol",single,8,14). bond("24-ethylidenelophenol",single,9,10). bond("24-ethylidenelophenol",single,9,11).
+bond("24-ethylidenelophenol",singleR,10,19). bond("24-ethylidenelophenol",single,11,12). bond("24-ethylidenelophenol",single,12,13).
+bond("24-ethylidenelophenol",single,13,14). bond("24-ethylidenelophenol",single,14,15). bond("24-ethylidenelophenol",single,15,16).
+bond("24-ethylidenelophenol",single,16,17). bond("24-ethylidenelophenol",single,13,17). bond("24-ethylidenelophenol",singleR,13,18).
+bond("24-ethylidenelophenol",singleR,17,20). bond("24-ethylidenelophenol",singleS,20,21). bond("24-ethylidenelophenol",single,20,22).
+bond("24-ethylidenelophenol",single,22,23). bond("24-ethylidenelophenol",single,23,24). bond("24-ethylidenelophenol",double,24,241).
+bond("24-ethylidenelophenol",single,241,242). bond("24-ethylidenelophenol",single,24,25). bond("24-ethylidenelophenol",single,25,26).
+bond("24-ethylidenelophenol",single,25,27).
 
 % 24-ethylenelophenol branch (PWY-8238)
 
@@ -248,7 +263,7 @@ bond("24-ethylenelophenol",singleR,10,19). bond("24-ethylenelophenol",single,11,
 bond("24-ethylenelophenol",single,13,14). bond("24-ethylenelophenol",single,14,15). bond("24-ethylenelophenol",single,15,16).
 bond("24-ethylenelophenol",single,16,17). bond("24-ethylenelophenol",single,13,17). bond("24-ethylenelophenol",singleR,13,18).
 bond("24-ethylenelophenol",singleR,17,20). bond("24-ethylenelophenol",singleS,20,21). bond("24-ethylenelophenol",single,20,22).
-bond("24-ethylenelophenol",single,22,23). bond("24-ethylenelophenol",single,23,24). bond("24-ethylenelophenol",doubleE,24,241).
+bond("24-ethylenelophenol",single,22,23). bond("24-ethylenelophenol",single,23,24). bond("24-ethylenelophenol",double,24,241).
 bond("24-ethylenelophenol",single,241,242). bond("24-ethylenelophenol",single,24,25). bond("24-ethylenelophenol",single,25,26).
 bond("24-ethylenelophenol",single,25,27).
 
@@ -263,7 +278,7 @@ bond("(24E)-4α-carboxy-stigmasta-7,24(241)-dien-3β-ol",singleR,10,19). bond("(
 bond("(24E)-4α-carboxy-stigmasta-7,24(241)-dien-3β-ol",single,13,14). bond("(24E)-4α-carboxy-stigmasta-7,24(241)-dien-3β-ol",single,14,15). bond("(24E)-4α-carboxy-stigmasta-7,24(241)-dien-3β-ol",single,15,16).
 bond("(24E)-4α-carboxy-stigmasta-7,24(241)-dien-3β-ol",single,16,17). bond("(24E)-4α-carboxy-stigmasta-7,24(241)-dien-3β-ol",single,13,17). bond("(24E)-4α-carboxy-stigmasta-7,24(241)-dien-3β-ol",singleR,13,18).
 bond("(24E)-4α-carboxy-stigmasta-7,24(241)-dien-3β-ol",singleR,17,20). bond("(24E)-4α-carboxy-stigmasta-7,24(241)-dien-3β-ol",singleS,20,21). bond("(24E)-4α-carboxy-stigmasta-7,24(241)-dien-3β-ol",single,20,22).
-bond("(24E)-4α-carboxy-stigmasta-7,24(241)-dien-3β-ol",single,22,23). bond("(24E)-4α-carboxy-stigmasta-7,24(241)-dien-3β-ol",single,23,24). bond("(24E)-4α-carboxy-stigmasta-7,24(241)-dien-3β-ol",doubleE,24,241).
+bond("(24E)-4α-carboxy-stigmasta-7,24(241)-dien-3β-ol",single,22,23). bond("(24E)-4α-carboxy-stigmasta-7,24(241)-dien-3β-ol",single,23,24). bond("(24E)-4α-carboxy-stigmasta-7,24(241)-dien-3β-ol",double,24,241).
 bond("(24E)-4α-carboxy-stigmasta-7,24(241)-dien-3β-ol",single,241,242). bond("(24E)-4α-carboxy-stigmasta-7,24(241)-dien-3β-ol",single,24,25). bond("(24E)-4α-carboxy-stigmasta-7,24(241)-dien-3β-ol",single,25,26).
 bond("(24E)-4α-carboxy-stigmasta-7,24(241)-dien-3β-ol",single,25,27). bond("(24E)-4α-carboxy-stigmasta-7,24(241)-dien-3β-ol",double,28,32). bond("(24E)-4α-carboxy-stigmasta-7,24(241)-dien-3β-ol",single,28,33).
 
@@ -278,7 +293,7 @@ bond("isoavenastenone",single,11,12). bond("isoavenastenone",single,12,13). bond
 bond("isoavenastenone",single,14,15). bond("isoavenastenone",single,15,16). bond("isoavenastenone",single,16,17).
 bond("isoavenastenone",single,13,17). bond("isoavenastenone",singleR,13,18). bond("isoavenastenone",singleR,17,20).
 bond("isoavenastenone",singleS,20,21). bond("isoavenastenone",single,20,22). bond("isoavenastenone",single,22,23).
-bond("isoavenastenone",single,23,24). bond("isoavenastenone",doubleE,24,241). bond("isoavenastenone",single,241,242).
+bond("isoavenastenone",single,23,24). bond("isoavenastenone",double,24,241). bond("isoavenastenone",single,241,242).
 bond("isoavenastenone",single,24,25). bond("isoavenastenone",single,25,26). bond("isoavenastenone",single,25,27).
 
 atom("isoavenasterol",1..24,carb). atom("isoavenasterol",241,carb). atom("isoavenasterol",242,carb).
@@ -292,7 +307,7 @@ bond("isoavenasterol",single,11,12). bond("isoavenasterol",single,12,13). bond("
 bond("isoavenasterol",single,14,15). bond("isoavenasterol",single,15,16). bond("isoavenasterol",single,16,17).
 bond("isoavenasterol",single,13,17). bond("isoavenasterol",singleR,13,18). bond("isoavenasterol",singleR,17,20).
 bond("isoavenasterol",singleS,20,21). bond("isoavenasterol",single,20,22). bond("isoavenasterol",single,22,23).
-bond("isoavenasterol",single,23,24). bond("isoavenasterol",doubleE,24,241). bond("isoavenasterol",single,241,242).
+bond("isoavenasterol",single,23,24). bond("isoavenasterol",double,24,241). bond("isoavenasterol",single,241,242).
 bond("isoavenasterol",single,24,25). bond("isoavenasterol",single,25,26). bond("isoavenasterol",single,25,27).
 
 atom("5-dehydroisoavenasterol",1..24,carb). atom("5-dehydroisoavenasterol",241,carb). atom("5-dehydroisoavenasterol",242,carb).
@@ -306,7 +321,7 @@ bond("5-dehydroisoavenasterol",single,11,12). bond("5-dehydroisoavenasterol",sin
 bond("5-dehydroisoavenasterol",single,14,15). bond("5-dehydroisoavenasterol",single,15,16). bond("5-dehydroisoavenasterol",single,16,17).
 bond("5-dehydroisoavenasterol",single,13,17). bond("5-dehydroisoavenasterol",singleR,13,18). bond("5-dehydroisoavenasterol",singleR,17,20).
 bond("5-dehydroisoavenasterol",singleS,20,21). bond("5-dehydroisoavenasterol",single,20,22). bond("5-dehydroisoavenasterol",single,22,23).
-bond("5-dehydroisoavenasterol",single,23,24). bond("5-dehydroisoavenasterol",doubleE,24,241). bond("5-dehydroisoavenasterol",single,241,242).
+bond("5-dehydroisoavenasterol",single,23,24). bond("5-dehydroisoavenasterol",double,24,241). bond("5-dehydroisoavenasterol",single,241,242).
 bond("5-dehydroisoavenasterol",single,24,25). bond("5-dehydroisoavenasterol",single,25,26). bond("5-dehydroisoavenasterol",single,25,27).
 
 atom("fucosterol",1..24,carb). atom("fucosterol",241,carb). atom("fucosterol",242,carb).
@@ -320,7 +335,7 @@ bond("fucosterol",single,11,12). bond("fucosterol",single,12,13). bond("fucoster
 bond("fucosterol",single,14,15). bond("fucosterol",single,15,16). bond("fucosterol",single,16,17).
 bond("fucosterol",single,13,17). bond("fucosterol",singleR,13,18). bond("fucosterol",singleR,17,20).
 bond("fucosterol",singleS,20,21). bond("fucosterol",single,20,22). bond("fucosterol",single,22,23).
-bond("fucosterol",single,23,24). bond("fucosterol",doubleE,24,241). bond("fucosterol",single,241,242).
+bond("fucosterol",single,23,24). bond("fucosterol",double,24,241). bond("fucosterol",single,241,242).
 bond("fucosterol",single,24,25). bond("fucosterol",single,25,26). bond("fucosterol",single,25,27).
 
 % episterol branch
@@ -336,7 +351,7 @@ bond("4α-hydroxymethyl-ergosta-7,24(241)-dien-3β-ol",singleR,10,19). bond("4α
 bond("4α-hydroxymethyl-ergosta-7,24(241)-dien-3β-ol",single,13,14). bond("4α-hydroxymethyl-ergosta-7,24(241)-dien-3β-ol",single,14,15). bond("4α-hydroxymethyl-ergosta-7,24(241)-dien-3β-ol",single,15,16).
 bond("4α-hydroxymethyl-ergosta-7,24(241)-dien-3β-ol",single,16,17). bond("4α-hydroxymethyl-ergosta-7,24(241)-dien-3β-ol",single,13,17). bond("4α-hydroxymethyl-ergosta-7,24(241)-dien-3β-ol",singleR,13,18).
 bond("4α-hydroxymethyl-ergosta-7,24(241)-dien-3β-ol",singleR,17,20). bond("4α-hydroxymethyl-ergosta-7,24(241)-dien-3β-ol",singleS,20,21). bond("4α-hydroxymethyl-ergosta-7,24(241)-dien-3β-ol",single,20,22).
-bond("4α-hydroxymethyl-ergosta-7,24(241)-dien-3β-ol",single,22,23). bond("4α-hydroxymethyl-ergosta-7,24(241)-dien-3β-ol",single,23,24). bond("4α-hydroxymethyl-ergosta-7,24(241)-dien-3β-ol",doubleE,24,241).
+bond("4α-hydroxymethyl-ergosta-7,24(241)-dien-3β-ol",single,22,23). bond("4α-hydroxymethyl-ergosta-7,24(241)-dien-3β-ol",single,23,24). bond("4α-hydroxymethyl-ergosta-7,24(241)-dien-3β-ol",double,24,241).
 bond("4α-hydroxymethyl-ergosta-7,24(241)-dien-3β-ol",single,24,25). bond("4α-hydroxymethyl-ergosta-7,24(241)-dien-3β-ol",single,25,26). bond("4α-hydroxymethyl-ergosta-7,24(241)-dien-3β-ol",single,25,27).
 bond("4α-hydroxymethyl-ergosta-7,24(241)-dien-3β-ol",single,28,32).
 
@@ -351,7 +366,7 @@ bond("4α-formyl-ergosta-7,24(241)-dien-3β-ol",singleR,10,19). bond("4α-formyl
 bond("4α-formyl-ergosta-7,24(241)-dien-3β-ol",single,13,14). bond("4α-formyl-ergosta-7,24(241)-dien-3β-ol",single,14,15). bond("4α-formyl-ergosta-7,24(241)-dien-3β-ol",single,15,16).
 bond("4α-formyl-ergosta-7,24(241)-dien-3β-ol",single,16,17). bond("4α-formyl-ergosta-7,24(241)-dien-3β-ol",single,13,17). bond("4α-formyl-ergosta-7,24(241)-dien-3β-ol",singleR,13,18).
 bond("4α-formyl-ergosta-7,24(241)-dien-3β-ol",singleR,17,20). bond("4α-formyl-ergosta-7,24(241)-dien-3β-ol",singleS,20,21). bond("4α-formyl-ergosta-7,24(241)-dien-3β-ol",single,20,22).
-bond("4α-formyl-ergosta-7,24(241)-dien-3β-ol",single,22,23). bond("4α-formyl-ergosta-7,24(241)-dien-3β-ol",single,23,24). bond("4α-formyl-ergosta-7,24(241)-dien-3β-ol",doubleE,24,241).
+bond("4α-formyl-ergosta-7,24(241)-dien-3β-ol",single,22,23). bond("4α-formyl-ergosta-7,24(241)-dien-3β-ol",single,23,24). bond("4α-formyl-ergosta-7,24(241)-dien-3β-ol",double,24,241).
 bond("4α-formyl-ergosta-7,24(241)-dien-3β-ol",single,24,25). bond("4α-formyl-ergosta-7,24(241)-dien-3β-ol",single,25,26). bond("4α-formyl-ergosta-7,24(241)-dien-3β-ol",single,25,27).
 bond("4α-formyl-ergosta-7,24(241)-dien-3β-ol",double,28,32).
 
@@ -366,7 +381,7 @@ bond("4α-carboxy-ergosta-7,24(241)-dien-3β-ol",singleR,10,19). bond("4α-carbo
 bond("4α-carboxy-ergosta-7,24(241)-dien-3β-ol",single,13,14). bond("4α-carboxy-ergosta-7,24(241)-dien-3β-ol",single,14,15). bond("4α-carboxy-ergosta-7,24(241)-dien-3β-ol",single,15,16).
 bond("4α-carboxy-ergosta-7,24(241)-dien-3β-ol",single,16,17). bond("4α-carboxy-ergosta-7,24(241)-dien-3β-ol",single,13,17). bond("4α-carboxy-ergosta-7,24(241)-dien-3β-ol",singleR,13,18).
 bond("4α-carboxy-ergosta-7,24(241)-dien-3β-ol",singleR,17,20). bond("4α-carboxy-ergosta-7,24(241)-dien-3β-ol",singleS,20,21). bond("4α-carboxy-ergosta-7,24(241)-dien-3β-ol",single,20,22).
-bond("4α-carboxy-ergosta-7,24(241)-dien-3β-ol",single,22,23). bond("4α-carboxy-ergosta-7,24(241)-dien-3β-ol",single,23,24). bond("4α-carboxy-ergosta-7,24(241)-dien-3β-ol",doubleE,24,241).
+bond("4α-carboxy-ergosta-7,24(241)-dien-3β-ol",single,22,23). bond("4α-carboxy-ergosta-7,24(241)-dien-3β-ol",single,23,24). bond("4α-carboxy-ergosta-7,24(241)-dien-3β-ol",double,24,241).
 bond("4α-carboxy-ergosta-7,24(241)-dien-3β-ol",single,24,25). bond("4α-carboxy-ergosta-7,24(241)-dien-3β-ol",single,25,26). bond("4α-carboxy-ergosta-7,24(241)-dien-3β-ol",single,25,27).
 bond("4α-carboxy-ergosta-7,24(241)-dien-3β-ol",double,28,32). bond("4α-carboxy-ergosta-7,24(241)-dien-3β-ol",double,28,33).
 
@@ -381,7 +396,7 @@ bond("episterone",single,11,12). bond("episterone",single,12,13). bond("epistero
 bond("episterone",single,14,15). bond("episterone",single,15,16). bond("episterone",single,16,17).
 bond("episterone",single,13,17). bond("episterone",singleR,13,18). bond("episterone",singleR,17,20).
 bond("episterone",singleS,20,21). bond("episterone",single,20,22). bond("episterone",single,22,23).
-bond("episterone",single,23,24). bond("episterone",doubleE,24,241). bond("episterone",single,24,25).
+bond("episterone",single,23,24). bond("episterone",double,24,241). bond("episterone",single,24,25).
 bond("episterone",single,25,26). bond("episterone",single,25,27).
 
 atom("episterol",1..24,carb). atom("episterol",241,carb). atom("episterol",25..27,carb).
@@ -395,7 +410,7 @@ bond("episterol",single,11,12). bond("episterol",single,12,13). bond("episterol"
 bond("episterol",single,14,15). bond("episterol",single,15,16). bond("episterol",single,16,17).
 bond("episterol",single,13,17). bond("episterol",singleR,13,18). bond("episterol",singleR,17,20).
 bond("episterol",singleS,20,21). bond("episterol",single,20,22). bond("episterol",single,22,23).
-bond("episterol",single,23,24). bond("episterol",doubleE,24,241). bond("episterol",single,24,25).
+bond("episterol",single,23,24). bond("episterol",double,24,241). bond("episterol",single,24,25).
 bond("episterol",single,25,26). bond("episterol",single,25,27).
 
 atom("ergosta-5,7,24(28)-trien-3β-ol",1..24,carb). atom("ergosta-5,7,24(28)-trien-3β-ol",241,carb). atom("ergosta-5,7,24(28)-trien-3β-ol",25..27,carb).
@@ -409,7 +424,7 @@ bond("ergosta-5,7,24(28)-trien-3β-ol",single,11,12). bond("ergosta-5,7,24(28)-t
 bond("ergosta-5,7,24(28)-trien-3β-ol",single,14,15). bond("ergosta-5,7,24(28)-trien-3β-ol",single,15,16). bond("ergosta-5,7,24(28)-trien-3β-ol",single,16,17).
 bond("ergosta-5,7,24(28)-trien-3β-ol",single,13,17). bond("ergosta-5,7,24(28)-trien-3β-ol",singleR,13,18). bond("ergosta-5,7,24(28)-trien-3β-ol",singleR,17,20).
 bond("ergosta-5,7,24(28)-trien-3β-ol",singleS,20,21). bond("ergosta-5,7,24(28)-trien-3β-ol",single,20,22). bond("ergosta-5,7,24(28)-trien-3β-ol",single,22,23).
-bond("ergosta-5,7,24(28)-trien-3β-ol",single,23,24). bond("ergosta-5,7,24(28)-trien-3β-ol",doubleE,24,241). bond("ergosta-5,7,24(28)-trien-3β-ol",single,24,25).
+bond("ergosta-5,7,24(28)-trien-3β-ol",single,23,24). bond("ergosta-5,7,24(28)-trien-3β-ol",double,24,241). bond("ergosta-5,7,24(28)-trien-3β-ol",single,24,25).
 bond("ergosta-5,7,24(28)-trien-3β-ol",single,25,26). bond("ergosta-5,7,24(28)-trien-3β-ol",single,25,27).
 
 % Sterols from PWY-8191
@@ -720,7 +735,7 @@ reaction(rxn3o_218,"episterol","ergosta-5,7,24(28)-trien-3β-ol").
 reaction(rxn_707,"ergosta-5,7,24(28)-trien-3β-ol","24-methylenecholesterol").
 reaction(rxn_4222,"24-methylenecholesterol","24-methyldesmosterol").
 reaction(rxn_708,"24-methyldesmosterol","campesterol").
-reaction(rxn_2_1_1_143,"24-methylenelophenol","24-ethylenelophenol").
+reaction(rxn_2_1_1_143,"24-methylenelophenol","24-ethylidenelophenol").
 reaction(rxn_20131,"24-methylenecholesterol","campesterol").
 reaction(c22_desaturation,"campesterol","brassicasterol").
 

--- a/pathmodel/data/brown_sterols_pwy.lp
+++ b/pathmodel/data/brown_sterols_pwy.lp
@@ -51,7 +51,7 @@ bond("24-methylenecholesterol",single,11,12). bond("24-methylenecholesterol",sin
 bond("24-methylenecholesterol",single,14,15). bond("24-methylenecholesterol",single,15,16). bond("24-methylenecholesterol",single,16,17).
 bond("24-methylenecholesterol",single,13,17). bond("24-methylenecholesterol",singleR,13,18). bond("24-methylenecholesterol",singleR,17,20).
 bond("24-methylenecholesterol",singleS,20,21). bond("24-methylenecholesterol",single,20,22). bond("24-methylenecholesterol",single,22,23).
-bond("24-methylenecholesterol",single,23,24). bond("24-methylenecholesterol",double,24,241). bond("24-methylenecholesterol",single,24,25).
+bond("24-methylenecholesterol",single,23,24). bond("24-methylenecholesterol",doubleE,24,241). bond("24-methylenecholesterol",single,24,25).
 bond("24-methylenecholesterol",single,25,26). bond("24-methylenecholesterol",single,25,27).
 
 
@@ -97,7 +97,7 @@ bond("24-methylenecycloartanol",single,11,12). bond("24-methylenecycloartanol",s
 bond("24-methylenecycloartanol",single,14,15). bond("24-methylenecycloartanol",singleS,14,30). bond("24-methylenecycloartanol",single,15,16).
 bond("24-methylenecycloartanol",single,16,17). bond("24-methylenecycloartanol",single,13,17). bond("24-methylenecycloartanol",singleR,13,18).
 bond("24-methylenecycloartanol",singleR,17,20). bond("24-methylenecycloartanol",singleS,20,21). bond("24-methylenecycloartanol",single,20,22).
-bond("24-methylenecycloartanol",single,22,23). bond("24-methylenecycloartanol",single,23,24). bond("24-methylenecycloartanol",double,24,241).
+bond("24-methylenecycloartanol",single,22,23). bond("24-methylenecycloartanol",single,23,24). bond("24-methylenecycloartanol",doubleE,24,241).
 bond("24-methylenecycloartanol",single,24,25). bond("24-methylenecycloartanol",single,25,26). bond("24-methylenecycloartanol",single,25,27).
 
 atom("4α-hydroxymethyl,4β,14α-dimethyl-9β,19-cyclo-5α-ergost-24(241)-en-3β-ol",1..24,carb). atom("4α-hydroxymethyl,4β,14α-dimethyl-9β,19-cyclo-5α-ergost-24(241)-en-3β-ol",241,carb). atom("4α-hydroxymethyl,4β,14α-dimethyl-9β,19-cyclo-5α-ergost-24(241)-en-3β-ol",25..30,carb).
@@ -112,7 +112,7 @@ bond("4α-hydroxymethyl,4β,14α-dimethyl-9β,19-cyclo-5α-ergost-24(241)-en-3β
 bond("4α-hydroxymethyl,4β,14α-dimethyl-9β,19-cyclo-5α-ergost-24(241)-en-3β-ol",single,14,15). bond("4α-hydroxymethyl,4β,14α-dimethyl-9β,19-cyclo-5α-ergost-24(241)-en-3β-ol",singleS,14,30). bond("4α-hydroxymethyl,4β,14α-dimethyl-9β,19-cyclo-5α-ergost-24(241)-en-3β-ol",single,15,16).
 bond("4α-hydroxymethyl,4β,14α-dimethyl-9β,19-cyclo-5α-ergost-24(241)-en-3β-ol",single,16,17). bond("4α-hydroxymethyl,4β,14α-dimethyl-9β,19-cyclo-5α-ergost-24(241)-en-3β-ol",single,13,17). bond("4α-hydroxymethyl,4β,14α-dimethyl-9β,19-cyclo-5α-ergost-24(241)-en-3β-ol",singleR,13,18).
 bond("4α-hydroxymethyl,4β,14α-dimethyl-9β,19-cyclo-5α-ergost-24(241)-en-3β-ol",singleR,17,20). bond("4α-hydroxymethyl,4β,14α-dimethyl-9β,19-cyclo-5α-ergost-24(241)-en-3β-ol",singleS,20,21). bond("4α-hydroxymethyl,4β,14α-dimethyl-9β,19-cyclo-5α-ergost-24(241)-en-3β-ol",single,20,22).
-bond("4α-hydroxymethyl,4β,14α-dimethyl-9β,19-cyclo-5α-ergost-24(241)-en-3β-ol",single,22,23). bond("4α-hydroxymethyl,4β,14α-dimethyl-9β,19-cyclo-5α-ergost-24(241)-en-3β-ol",single,23,24). bond("4α-hydroxymethyl,4β,14α-dimethyl-9β,19-cyclo-5α-ergost-24(241)-en-3β-ol",double,24,241).
+bond("4α-hydroxymethyl,4β,14α-dimethyl-9β,19-cyclo-5α-ergost-24(241)-en-3β-ol",single,22,23). bond("4α-hydroxymethyl,4β,14α-dimethyl-9β,19-cyclo-5α-ergost-24(241)-en-3β-ol",single,23,24). bond("4α-hydroxymethyl,4β,14α-dimethyl-9β,19-cyclo-5α-ergost-24(241)-en-3β-ol",doubleE,24,241).
 bond("4α-hydroxymethyl,4β,14α-dimethyl-9β,19-cyclo-5α-ergost-24(241)-en-3β-ol",single,24,25). bond("4α-hydroxymethyl,4β,14α-dimethyl-9β,19-cyclo-5α-ergost-24(241)-en-3β-ol",single,25,26). bond("4α-hydroxymethyl,4β,14α-dimethyl-9β,19-cyclo-5α-ergost-24(241)-en-3β-ol",single,25,27).
 bond("4α-hydroxymethyl,4β,14α-dimethyl-9β,19-cyclo-5α-ergost-24(241)-en-3β-ol",single,28,32).
 
@@ -128,7 +128,7 @@ bond("4α-formyl,4β,14α-dimethyl-9β,19-cyclo-5α-ergost-24(241)-en-3β-ol",si
 bond("4α-formyl,4β,14α-dimethyl-9β,19-cyclo-5α-ergost-24(241)-en-3β-ol",single,14,15). bond("4α-formyl,4β,14α-dimethyl-9β,19-cyclo-5α-ergost-24(241)-en-3β-ol",singleS,14,30). bond("4α-formyl,4β,14α-dimethyl-9β,19-cyclo-5α-ergost-24(241)-en-3β-ol",single,15,16).
 bond("4α-formyl,4β,14α-dimethyl-9β,19-cyclo-5α-ergost-24(241)-en-3β-ol",single,16,17). bond("4α-formyl,4β,14α-dimethyl-9β,19-cyclo-5α-ergost-24(241)-en-3β-ol",single,13,17). bond("4α-formyl,4β,14α-dimethyl-9β,19-cyclo-5α-ergost-24(241)-en-3β-ol",singleR,13,18).
 bond("4α-formyl,4β,14α-dimethyl-9β,19-cyclo-5α-ergost-24(241)-en-3β-ol",singleR,17,20). bond("4α-formyl,4β,14α-dimethyl-9β,19-cyclo-5α-ergost-24(241)-en-3β-ol",singleS,20,21). bond("4α-formyl,4β,14α-dimethyl-9β,19-cyclo-5α-ergost-24(241)-en-3β-ol",single,20,22).
-bond("4α-formyl,4β,14α-dimethyl-9β,19-cyclo-5α-ergost-24(241)-en-3β-ol",single,22,23). bond("4α-formyl,4β,14α-dimethyl-9β,19-cyclo-5α-ergost-24(241)-en-3β-ol",single,23,24). bond("4α-formyl,4β,14α-dimethyl-9β,19-cyclo-5α-ergost-24(241)-en-3β-ol",double,24,241).
+bond("4α-formyl,4β,14α-dimethyl-9β,19-cyclo-5α-ergost-24(241)-en-3β-ol",single,22,23). bond("4α-formyl,4β,14α-dimethyl-9β,19-cyclo-5α-ergost-24(241)-en-3β-ol",single,23,24). bond("4α-formyl,4β,14α-dimethyl-9β,19-cyclo-5α-ergost-24(241)-en-3β-ol",doubleE,24,241).
 bond("4α-formyl,4β,14α-dimethyl-9β,19-cyclo-5α-ergost-24(241)-en-3β-ol",single,24,25). bond("4α-formyl,4β,14α-dimethyl-9β,19-cyclo-5α-ergost-24(241)-en-3β-ol",single,25,26). bond("4α-formyl,4β,14α-dimethyl-9β,19-cyclo-5α-ergost-24(241)-en-3β-ol",single,25,27).
 bond("4α-formyl,4β,14α-dimethyl-9β,19-cyclo-5α-ergost-24(241)-en-3β-ol",double,28,32).
 
@@ -144,7 +144,7 @@ bond("4α-carboxy-4β,14α-dimethyl-9β,19-cyclo-5α-ergost-24(241)-en-3β-ol",s
 bond("4α-carboxy-4β,14α-dimethyl-9β,19-cyclo-5α-ergost-24(241)-en-3β-ol",single,14,15). bond("4α-carboxy-4β,14α-dimethyl-9β,19-cyclo-5α-ergost-24(241)-en-3β-ol",singleS,14,30). bond("4α-carboxy-4β,14α-dimethyl-9β,19-cyclo-5α-ergost-24(241)-en-3β-ol",single,15,16).
 bond("4α-carboxy-4β,14α-dimethyl-9β,19-cyclo-5α-ergost-24(241)-en-3β-ol",single,16,17). bond("4α-carboxy-4β,14α-dimethyl-9β,19-cyclo-5α-ergost-24(241)-en-3β-ol",single,13,17). bond("4α-carboxy-4β,14α-dimethyl-9β,19-cyclo-5α-ergost-24(241)-en-3β-ol",singleR,13,18).
 bond("4α-carboxy-4β,14α-dimethyl-9β,19-cyclo-5α-ergost-24(241)-en-3β-ol",singleR,17,20). bond("4α-carboxy-4β,14α-dimethyl-9β,19-cyclo-5α-ergost-24(241)-en-3β-ol",singleS,20,21). bond("4α-carboxy-4β,14α-dimethyl-9β,19-cyclo-5α-ergost-24(241)-en-3β-ol",single,20,22).
-bond("4α-carboxy-4β,14α-dimethyl-9β,19-cyclo-5α-ergost-24(241)-en-3β-ol",single,22,23). bond("4α-carboxy-4β,14α-dimethyl-9β,19-cyclo-5α-ergost-24(241)-en-3β-ol",single,23,24). bond("4α-carboxy-4β,14α-dimethyl-9β,19-cyclo-5α-ergost-24(241)-en-3β-ol",double,24,241).
+bond("4α-carboxy-4β,14α-dimethyl-9β,19-cyclo-5α-ergost-24(241)-en-3β-ol",single,22,23). bond("4α-carboxy-4β,14α-dimethyl-9β,19-cyclo-5α-ergost-24(241)-en-3β-ol",single,23,24). bond("4α-carboxy-4β,14α-dimethyl-9β,19-cyclo-5α-ergost-24(241)-en-3β-ol",doubleE,24,241).
 bond("4α-carboxy-4β,14α-dimethyl-9β,19-cyclo-5α-ergost-24(241)-en-3β-ol",single,24,25). bond("4α-carboxy-4β,14α-dimethyl-9β,19-cyclo-5α-ergost-24(241)-en-3β-ol",single,25,26). bond("4α-carboxy-4β,14α-dimethyl-9β,19-cyclo-5α-ergost-24(241)-en-3β-ol",single,25,27).
 bond("4α-carboxy-4β,14α-dimethyl-9β,19-cyclo-5α-ergost-24(241)-en-3β-ol",double,28,32). bond("4α-carboxy-4β,14α-dimethyl-9β,19-cyclo-5α-ergost-24(241)-en-3β-ol",single,28,33).
 
@@ -160,7 +160,7 @@ bond("cycloeucalenone",single,12,13). bond("cycloeucalenone",single,13,14). bond
 bond("cycloeucalenone",singleS,14,30). bond("cycloeucalenone",single,15,16). bond("cycloeucalenone",single,16,17).
 bond("cycloeucalenone",single,13,17). bond("cycloeucalenone",singleR,13,18). bond("cycloeucalenone",singleR,17,20).
 bond("cycloeucalenone",singleS,20,21). bond("cycloeucalenone",single,20,22). bond("cycloeucalenone",single,22,23).
-bond("cycloeucalenone",single,23,24). bond("cycloeucalenone",double,24,241). bond("cycloeucalenone",single,24,25).
+bond("cycloeucalenone",single,23,24). bond("cycloeucalenone",doubleE,24,241). bond("cycloeucalenone",single,24,25).
 bond("cycloeucalenone",single,25,26). bond("cycloeucalenone",single,25,27).
 
 atom("cycloeucalenol",1..24,carb). atom("cycloeucalenol",241,carb). atom("cycloeucalenol",25..28,carb).
@@ -175,7 +175,7 @@ bond("cycloeucalenol",single,12,13). bond("cycloeucalenol",single,13,14). bond("
 bond("cycloeucalenol",singleS,14,30). bond("cycloeucalenol",single,15,16). bond("cycloeucalenol",single,16,17).
 bond("cycloeucalenol",single,13,17). bond("cycloeucalenol",singleR,13,18). bond("cycloeucalenol",singleR,17,20).
 bond("cycloeucalenol",singleS,20,21). bond("cycloeucalenol",single,20,22). bond("cycloeucalenol",single,22,23).
-bond("cycloeucalenol",single,23,24). bond("cycloeucalenol",double,24,241). bond("cycloeucalenol",single,24,25).
+bond("cycloeucalenol",single,23,24). bond("cycloeucalenol",doubleE,24,241). bond("cycloeucalenol",single,24,25).
 bond("cycloeucalenol",single,25,26). bond("cycloeucalenol",single,25,27).
 
 atom("obtusifoliol",1..24,carb). atom("obtusifoliol",241,carb). atom("obtusifoliol",25..28,carb).
@@ -190,7 +190,7 @@ bond("obtusifoliol",single,13,14). bond("obtusifoliol",single,14,15). bond("obtu
 bond("obtusifoliol",single,15,16). bond("obtusifoliol",single,16,17). bond("obtusifoliol",single,13,17).
 bond("obtusifoliol",singleR,13,18). bond("obtusifoliol",singleR,17,20). bond("obtusifoliol",singleS,20,21).
 bond("obtusifoliol",single,20,22). bond("obtusifoliol",single,22,23). bond("obtusifoliol",single,23,24).
-bond("obtusifoliol",double,24,241). bond("obtusifoliol",single,24,25). bond("obtusifoliol",single,25,26).
+bond("obtusifoliol",doubleE,24,241). bond("obtusifoliol",single,24,25). bond("obtusifoliol",single,25,26).
 bond("obtusifoliol",single,25,27).
 
 atom("4α-methyl-5α-ergosta-8,14,24(28)-trien-3β-ol",1..24,carb). atom("4α-methyl-5α-ergosta-8,14,24(28)-trien-3β-ol",241,carb). atom("4α-methyl-5α-ergosta-8,14,24(28)-trien-3β-ol",25..28,carb).
@@ -204,7 +204,7 @@ bond("4α-methyl-5α-ergosta-8,14,24(28)-trien-3β-ol",singleR,10,19). bond("4α
 bond("4α-methyl-5α-ergosta-8,14,24(28)-trien-3β-ol",single,13,14). bond("4α-methyl-5α-ergosta-8,14,24(28)-trien-3β-ol",double,14,15). bond("4α-methyl-5α-ergosta-8,14,24(28)-trien-3β-ol",single,15,16).
 bond("4α-methyl-5α-ergosta-8,14,24(28)-trien-3β-ol",single,16,17). bond("4α-methyl-5α-ergosta-8,14,24(28)-trien-3β-ol",single,13,17). bond("4α-methyl-5α-ergosta-8,14,24(28)-trien-3β-ol",singleR,13,18).
 bond("4α-methyl-5α-ergosta-8,14,24(28)-trien-3β-ol",singleR,17,20). bond("4α-methyl-5α-ergosta-8,14,24(28)-trien-3β-ol",singleS,20,21). bond("4α-methyl-5α-ergosta-8,14,24(28)-trien-3β-ol",single,20,22).
-bond("4α-methyl-5α-ergosta-8,14,24(28)-trien-3β-ol",single,22,23). bond("4α-methyl-5α-ergosta-8,14,24(28)-trien-3β-ol",single,23,24). bond("4α-methyl-5α-ergosta-8,14,24(28)-trien-3β-ol",double,24,241).
+bond("4α-methyl-5α-ergosta-8,14,24(28)-trien-3β-ol",single,22,23). bond("4α-methyl-5α-ergosta-8,14,24(28)-trien-3β-ol",single,23,24). bond("4α-methyl-5α-ergosta-8,14,24(28)-trien-3β-ol",doubleE,24,241).
 bond("4α-methyl-5α-ergosta-8,14,24(28)-trien-3β-ol",single,24,25). bond("4α-methyl-5α-ergosta-8,14,24(28)-trien-3β-ol",single,25,26). bond("4α-methyl-5α-ergosta-8,14,24(28)-trien-3β-ol",single,25,27).
 
 atom("4α-methyl-5α-ergosta-8,24-dien-3β-ol",1..24,carb). atom("4α-methyl-5α-ergosta-8,24-dien-3β-ol",241,carb). atom("4α-methyl-5α-ergosta-8,24-dien-3β-ol",25..28,carb).
@@ -218,7 +218,7 @@ bond("4α-methyl-5α-ergosta-8,24-dien-3β-ol",singleR,10,19). bond("4α-methyl-
 bond("4α-methyl-5α-ergosta-8,24-dien-3β-ol",single,13,14). bond("4α-methyl-5α-ergosta-8,24-dien-3β-ol",single,14,15). bond("4α-methyl-5α-ergosta-8,24-dien-3β-ol",single,15,16).
 bond("4α-methyl-5α-ergosta-8,24-dien-3β-ol",single,16,17). bond("4α-methyl-5α-ergosta-8,24-dien-3β-ol",single,13,17). bond("4α-methyl-5α-ergosta-8,24-dien-3β-ol",singleR,13,18).
 bond("4α-methyl-5α-ergosta-8,24-dien-3β-ol",singleR,17,20). bond("4α-methyl-5α-ergosta-8,24-dien-3β-ol",singleS,20,21). bond("4α-methyl-5α-ergosta-8,24-dien-3β-ol",single,20,22).
-bond("4α-methyl-5α-ergosta-8,24-dien-3β-ol",single,22,23). bond("4α-methyl-5α-ergosta-8,24-dien-3β-ol",single,23,24). bond("4α-methyl-5α-ergosta-8,24-dien-3β-ol",double,24,241).
+bond("4α-methyl-5α-ergosta-8,24-dien-3β-ol",single,22,23). bond("4α-methyl-5α-ergosta-8,24-dien-3β-ol",single,23,24). bond("4α-methyl-5α-ergosta-8,24-dien-3β-ol",doubleE,24,241).
 bond("4α-methyl-5α-ergosta-8,24-dien-3β-ol",single,24,25). bond("4α-methyl-5α-ergosta-8,24-dien-3β-ol",single,25,26). bond("4α-methyl-5α-ergosta-8,24-dien-3β-ol",single,25,27).
 
 atom("24-methylenelophenol",1..24,carb). atom("24-methylenelophenol",241,carb). atom("24-methylenelophenol",25..28,carb).
@@ -232,7 +232,7 @@ bond("24-methylenelophenol",singleR,10,19). bond("24-methylenelophenol",single,1
 bond("24-methylenelophenol",single,13,14). bond("24-methylenelophenol",single,14,15). bond("24-methylenelophenol",single,15,16).
 bond("24-methylenelophenol",single,16,17). bond("24-methylenelophenol",single,13,17). bond("24-methylenelophenol",singleR,13,18).
 bond("24-methylenelophenol",singleR,17,20). bond("24-methylenelophenol",singleS,20,21). bond("24-methylenelophenol",single,20,22).
-bond("24-methylenelophenol",single,22,23). bond("24-methylenelophenol",single,23,24). bond("24-methylenelophenol",double,24,241).
+bond("24-methylenelophenol",single,22,23). bond("24-methylenelophenol",single,23,24). bond("24-methylenelophenol",doubleE,24,241).
 bond("24-methylenelophenol",single,24,25). bond("24-methylenelophenol",single,25,26). bond("24-methylenelophenol",single,25,27).
 
 % 24-ethylenelophenol branch (PWY-8238)
@@ -336,7 +336,7 @@ bond("4α-hydroxymethyl-ergosta-7,24(241)-dien-3β-ol",singleR,10,19). bond("4α
 bond("4α-hydroxymethyl-ergosta-7,24(241)-dien-3β-ol",single,13,14). bond("4α-hydroxymethyl-ergosta-7,24(241)-dien-3β-ol",single,14,15). bond("4α-hydroxymethyl-ergosta-7,24(241)-dien-3β-ol",single,15,16).
 bond("4α-hydroxymethyl-ergosta-7,24(241)-dien-3β-ol",single,16,17). bond("4α-hydroxymethyl-ergosta-7,24(241)-dien-3β-ol",single,13,17). bond("4α-hydroxymethyl-ergosta-7,24(241)-dien-3β-ol",singleR,13,18).
 bond("4α-hydroxymethyl-ergosta-7,24(241)-dien-3β-ol",singleR,17,20). bond("4α-hydroxymethyl-ergosta-7,24(241)-dien-3β-ol",singleS,20,21). bond("4α-hydroxymethyl-ergosta-7,24(241)-dien-3β-ol",single,20,22).
-bond("4α-hydroxymethyl-ergosta-7,24(241)-dien-3β-ol",single,22,23). bond("4α-hydroxymethyl-ergosta-7,24(241)-dien-3β-ol",single,23,24). bond("4α-hydroxymethyl-ergosta-7,24(241)-dien-3β-ol",double,24,241).
+bond("4α-hydroxymethyl-ergosta-7,24(241)-dien-3β-ol",single,22,23). bond("4α-hydroxymethyl-ergosta-7,24(241)-dien-3β-ol",single,23,24). bond("4α-hydroxymethyl-ergosta-7,24(241)-dien-3β-ol",doubleE,24,241).
 bond("4α-hydroxymethyl-ergosta-7,24(241)-dien-3β-ol",single,24,25). bond("4α-hydroxymethyl-ergosta-7,24(241)-dien-3β-ol",single,25,26). bond("4α-hydroxymethyl-ergosta-7,24(241)-dien-3β-ol",single,25,27).
 bond("4α-hydroxymethyl-ergosta-7,24(241)-dien-3β-ol",single,28,32).
 
@@ -351,7 +351,7 @@ bond("4α-formyl-ergosta-7,24(241)-dien-3β-ol",singleR,10,19). bond("4α-formyl
 bond("4α-formyl-ergosta-7,24(241)-dien-3β-ol",single,13,14). bond("4α-formyl-ergosta-7,24(241)-dien-3β-ol",single,14,15). bond("4α-formyl-ergosta-7,24(241)-dien-3β-ol",single,15,16).
 bond("4α-formyl-ergosta-7,24(241)-dien-3β-ol",single,16,17). bond("4α-formyl-ergosta-7,24(241)-dien-3β-ol",single,13,17). bond("4α-formyl-ergosta-7,24(241)-dien-3β-ol",singleR,13,18).
 bond("4α-formyl-ergosta-7,24(241)-dien-3β-ol",singleR,17,20). bond("4α-formyl-ergosta-7,24(241)-dien-3β-ol",singleS,20,21). bond("4α-formyl-ergosta-7,24(241)-dien-3β-ol",single,20,22).
-bond("4α-formyl-ergosta-7,24(241)-dien-3β-ol",single,22,23). bond("4α-formyl-ergosta-7,24(241)-dien-3β-ol",single,23,24). bond("4α-formyl-ergosta-7,24(241)-dien-3β-ol",double,24,241).
+bond("4α-formyl-ergosta-7,24(241)-dien-3β-ol",single,22,23). bond("4α-formyl-ergosta-7,24(241)-dien-3β-ol",single,23,24). bond("4α-formyl-ergosta-7,24(241)-dien-3β-ol",doubleE,24,241).
 bond("4α-formyl-ergosta-7,24(241)-dien-3β-ol",single,24,25). bond("4α-formyl-ergosta-7,24(241)-dien-3β-ol",single,25,26). bond("4α-formyl-ergosta-7,24(241)-dien-3β-ol",single,25,27).
 bond("4α-formyl-ergosta-7,24(241)-dien-3β-ol",double,28,32).
 
@@ -366,7 +366,7 @@ bond("4α-carboxy-ergosta-7,24(241)-dien-3β-ol",singleR,10,19). bond("4α-carbo
 bond("4α-carboxy-ergosta-7,24(241)-dien-3β-ol",single,13,14). bond("4α-carboxy-ergosta-7,24(241)-dien-3β-ol",single,14,15). bond("4α-carboxy-ergosta-7,24(241)-dien-3β-ol",single,15,16).
 bond("4α-carboxy-ergosta-7,24(241)-dien-3β-ol",single,16,17). bond("4α-carboxy-ergosta-7,24(241)-dien-3β-ol",single,13,17). bond("4α-carboxy-ergosta-7,24(241)-dien-3β-ol",singleR,13,18).
 bond("4α-carboxy-ergosta-7,24(241)-dien-3β-ol",singleR,17,20). bond("4α-carboxy-ergosta-7,24(241)-dien-3β-ol",singleS,20,21). bond("4α-carboxy-ergosta-7,24(241)-dien-3β-ol",single,20,22).
-bond("4α-carboxy-ergosta-7,24(241)-dien-3β-ol",single,22,23). bond("4α-carboxy-ergosta-7,24(241)-dien-3β-ol",single,23,24). bond("4α-carboxy-ergosta-7,24(241)-dien-3β-ol",double,24,241).
+bond("4α-carboxy-ergosta-7,24(241)-dien-3β-ol",single,22,23). bond("4α-carboxy-ergosta-7,24(241)-dien-3β-ol",single,23,24). bond("4α-carboxy-ergosta-7,24(241)-dien-3β-ol",doubleE,24,241).
 bond("4α-carboxy-ergosta-7,24(241)-dien-3β-ol",single,24,25). bond("4α-carboxy-ergosta-7,24(241)-dien-3β-ol",single,25,26). bond("4α-carboxy-ergosta-7,24(241)-dien-3β-ol",single,25,27).
 bond("4α-carboxy-ergosta-7,24(241)-dien-3β-ol",double,28,32). bond("4α-carboxy-ergosta-7,24(241)-dien-3β-ol",double,28,33).
 
@@ -381,7 +381,7 @@ bond("episterone",single,11,12). bond("episterone",single,12,13). bond("epistero
 bond("episterone",single,14,15). bond("episterone",single,15,16). bond("episterone",single,16,17).
 bond("episterone",single,13,17). bond("episterone",singleR,13,18). bond("episterone",singleR,17,20).
 bond("episterone",singleS,20,21). bond("episterone",single,20,22). bond("episterone",single,22,23).
-bond("episterone",single,23,24). bond("episterone",double,24,241). bond("episterone",single,24,25).
+bond("episterone",single,23,24). bond("episterone",doubleE,24,241). bond("episterone",single,24,25).
 bond("episterone",single,25,26). bond("episterone",single,25,27).
 
 atom("episterol",1..24,carb). atom("episterol",241,carb). atom("episterol",25..27,carb).
@@ -395,7 +395,7 @@ bond("episterol",single,11,12). bond("episterol",single,12,13). bond("episterol"
 bond("episterol",single,14,15). bond("episterol",single,15,16). bond("episterol",single,16,17).
 bond("episterol",single,13,17). bond("episterol",singleR,13,18). bond("episterol",singleR,17,20).
 bond("episterol",singleS,20,21). bond("episterol",single,20,22). bond("episterol",single,22,23).
-bond("episterol",single,23,24). bond("episterol",double,24,241). bond("episterol",single,24,25).
+bond("episterol",single,23,24). bond("episterol",doubleE,24,241). bond("episterol",single,24,25).
 bond("episterol",single,25,26). bond("episterol",single,25,27).
 
 atom("ergosta-5,7,24(28)-trien-3β-ol",1..24,carb). atom("ergosta-5,7,24(28)-trien-3β-ol",241,carb). atom("ergosta-5,7,24(28)-trien-3β-ol",25..27,carb).
@@ -409,7 +409,7 @@ bond("ergosta-5,7,24(28)-trien-3β-ol",single,11,12). bond("ergosta-5,7,24(28)-t
 bond("ergosta-5,7,24(28)-trien-3β-ol",single,14,15). bond("ergosta-5,7,24(28)-trien-3β-ol",single,15,16). bond("ergosta-5,7,24(28)-trien-3β-ol",single,16,17).
 bond("ergosta-5,7,24(28)-trien-3β-ol",single,13,17). bond("ergosta-5,7,24(28)-trien-3β-ol",singleR,13,18). bond("ergosta-5,7,24(28)-trien-3β-ol",singleR,17,20).
 bond("ergosta-5,7,24(28)-trien-3β-ol",singleS,20,21). bond("ergosta-5,7,24(28)-trien-3β-ol",single,20,22). bond("ergosta-5,7,24(28)-trien-3β-ol",single,22,23).
-bond("ergosta-5,7,24(28)-trien-3β-ol",single,23,24). bond("ergosta-5,7,24(28)-trien-3β-ol",double,24,241). bond("ergosta-5,7,24(28)-trien-3β-ol",single,24,25).
+bond("ergosta-5,7,24(28)-trien-3β-ol",single,23,24). bond("ergosta-5,7,24(28)-trien-3β-ol",doubleE,24,241). bond("ergosta-5,7,24(28)-trien-3β-ol",single,24,25).
 bond("ergosta-5,7,24(28)-trien-3β-ol",single,25,26). bond("ergosta-5,7,24(28)-trien-3β-ol",single,25,27).
 
 % Sterols from PWY-8191
@@ -720,17 +720,17 @@ reaction(rxn3o_218,"episterol","ergosta-5,7,24(28)-trien-3β-ol").
 reaction(rxn_707,"ergosta-5,7,24(28)-trien-3β-ol","24-methylenecholesterol").
 reaction(rxn_4222,"24-methylenecholesterol","24-methyldesmosterol").
 reaction(rxn_708,"24-methyldesmosterol","campesterol").
-reaction(rxn_2_1_1_143,"24-methylenelophenol","24-ethylidenelophenol").
+reaction(rxn_2_1_1_143,"24-methylenelophenol","24-ethylenelophenol").
 reaction(rxn_20131,"24-methylenecholesterol","campesterol").
 reaction(c22_desaturation,"campesterol","brassicasterol").
 
 %PWY-8238
 reaction(rxn_22199,"24-methylenelophenol","24-ethylenelophenol").
 reaction(rxn_22203,"24-ethylenelophenol","(24E)-4α-carboxy-stigmasta-7,24(241)-dien-3β-ol").
-reactions(rxn_22204,"(24E)-4α-carboxy-stigmasta-7,24(241)-dien-3β-ol","isoavenasterone").
-reaction(rxn_22205,"isoavenasterone","isoavenasterol").
-reaction(rxn_22206,"isoavenasterol","5-dehydroavenasterol").
-reaction(rxn_22198,"5-dehydroavenasterol","fucosterol").
+reaction(rxn_22204,"(24E)-4α-carboxy-stigmasta-7,24(241)-dien-3β-ol","isoavenastenone").
+reaction(rxn_22205,"isoavenastenone","isoavenasterol").
+reaction(rxn_22206,"isoavenasterol","5-dehydroisoavenasterol").
+reaction(rxn_22198,"5-dehydroisoavenasterol","fucosterol").
 
 % Molecules absent in the organism.
 

--- a/pathmodel/data/brown_sterols_pwy.lp
+++ b/pathmodel/data/brown_sterols_pwy.lp
@@ -235,109 +235,79 @@ bond("24-methylenelophenol",singleR,17,20). bond("24-methylenelophenol",singleS,
 bond("24-methylenelophenol",single,22,23). bond("24-methylenelophenol",single,23,24). bond("24-methylenelophenol",double,24,241).
 bond("24-methylenelophenol",single,24,25). bond("24-methylenelophenol",single,25,26). bond("24-methylenelophenol",single,25,27).
 
-% 24-ethylidenelophenol branch
+% 24-ethylenelophenol branch (PWY-8238)
 
-atom("24-ethylidenelophenol",1..24,carb). atom("24-ethylidenelophenol",241,carb). atom("24-ethylidenelophenol",242,carb).
-atom("24-ethylidenelophenol",25..28,carb). atom("24-ethylidenelophenol",31,oxyg).
-bond("24-ethylidenelophenol",single,1,2). bond("24-ethylidenelophenol",single,1,10). bond("24-ethylidenelophenol",single,2,3).
-bond("24-ethylidenelophenol",single,3,4). bond("24-ethylidenelophenol",singleR,3,31). bond("24-ethylidenelophenol",single,4,5).
-bond("24-ethylidenelophenol",singleS,4,28). bond("24-ethylidenelophenol",single,5,6). bond("24-ethylidenelophenol",single,5,10).
-bond("24-ethylidenelophenol",single,6,7). bond("24-ethylidenelophenol",double,7,8). bond("24-ethylidenelophenol",single,8,9).
-bond("24-ethylidenelophenol",single,8,14). bond("24-ethylidenelophenol",single,9,10). bond("24-ethylidenelophenol",single,9,11).
-bond("24-ethylidenelophenol",singleR,10,19). bond("24-ethylidenelophenol",single,11,12). bond("24-ethylidenelophenol",single,12,13).
-bond("24-ethylidenelophenol",single,13,14). bond("24-ethylidenelophenol",single,14,15). bond("24-ethylidenelophenol",single,15,16).
-bond("24-ethylidenelophenol",single,16,17). bond("24-ethylidenelophenol",single,13,17). bond("24-ethylidenelophenol",singleR,13,18).
-bond("24-ethylidenelophenol",singleR,17,20). bond("24-ethylidenelophenol",singleS,20,21). bond("24-ethylidenelophenol",single,20,22).
-bond("24-ethylidenelophenol",single,22,23). bond("24-ethylidenelophenol",single,23,24). bond("24-ethylidenelophenol",double,24,241).
-bond("24-ethylidenelophenol",single,241,242). bond("24-ethylidenelophenol",single,24,25). bond("24-ethylidenelophenol",single,25,26).
-bond("24-ethylidenelophenol",single,25,27).
+atom("24-ethylenelophenol",1..24,carb). atom("24-ethylenelophenol",241,carb). atom("24-ethylenelophenol",242,carb).
+atom("24-ethylenelophenol",25..28,carb). atom("24-ethylenelophenol",31,oxyg).
+bond("24-ethylenelophenol",single,1,2). bond("24-ethylenelophenol",single,1,10). bond("24-ethylenelophenol",single,2,3).
+bond("24-ethylenelophenol",single,3,4). bond("24-ethylenelophenol",singleR,3,31). bond("24-ethylenelophenol",single,4,5).
+bond("24-ethylenelophenol",singleS,4,28). bond("24-ethylenelophenol",single,5,6). bond("24-ethylenelophenol",single,5,10).
+bond("24-ethylenelophenol",single,6,7). bond("24-ethylenelophenol",double,7,8). bond("24-ethylenelophenol",single,8,9).
+bond("24-ethylenelophenol",single,8,14). bond("24-ethylenelophenol",single,9,10). bond("24-ethylenelophenol",single,9,11).
+bond("24-ethylenelophenol",singleR,10,19). bond("24-ethylenelophenol",single,11,12). bond("24-ethylenelophenol",single,12,13).
+bond("24-ethylenelophenol",single,13,14). bond("24-ethylenelophenol",single,14,15). bond("24-ethylenelophenol",single,15,16).
+bond("24-ethylenelophenol",single,16,17). bond("24-ethylenelophenol",single,13,17). bond("24-ethylenelophenol",singleR,13,18).
+bond("24-ethylenelophenol",singleR,17,20). bond("24-ethylenelophenol",singleS,20,21). bond("24-ethylenelophenol",single,20,22).
+bond("24-ethylenelophenol",single,22,23). bond("24-ethylenelophenol",single,23,24). bond("24-ethylenelophenol",doubleE,24,241).
+bond("24-ethylenelophenol",single,241,242). bond("24-ethylenelophenol",single,24,25). bond("24-ethylenelophenol",single,25,26).
+bond("24-ethylenelophenol",single,25,27).
 
-atom("4α-hydroxymethyl-stigmasta-7,24(241)-dien-3β-ol",1..24,carb). atom("4α-hydroxymethyl-stigmasta-7,24(241)-dien-3β-ol",241,carb). atom("4α-hydroxymethyl-stigmasta-7,24(241)-dien-3β-ol",242,carb).
-atom("4α-hydroxymethyl-stigmasta-7,24(241)-dien-3β-ol",25..28,carb). atom("4α-hydroxymethyl-stigmasta-7,24(241)-dien-3β-ol",31..32,oxyg).
-bond("4α-hydroxymethyl-stigmasta-7,24(241)-dien-3β-ol",single,1,2). bond("4α-hydroxymethyl-stigmasta-7,24(241)-dien-3β-ol",single,1,10). bond("4α-hydroxymethyl-stigmasta-7,24(241)-dien-3β-ol",single,2,3).
-bond("4α-hydroxymethyl-stigmasta-7,24(241)-dien-3β-ol",single,3,4). bond("4α-hydroxymethyl-stigmasta-7,24(241)-dien-3β-ol",singleR,3,31). bond("4α-hydroxymethyl-stigmasta-7,24(241)-dien-3β-ol",single,4,5).
-bond("4α-hydroxymethyl-stigmasta-7,24(241)-dien-3β-ol",singleS,4,28). bond("4α-hydroxymethyl-stigmasta-7,24(241)-dien-3β-ol",single,5,6). bond("4α-hydroxymethyl-stigmasta-7,24(241)-dien-3β-ol",single,5,10).
-bond("4α-hydroxymethyl-stigmasta-7,24(241)-dien-3β-ol",single,6,7). bond("4α-hydroxymethyl-stigmasta-7,24(241)-dien-3β-ol",double,7,8). bond("4α-hydroxymethyl-stigmasta-7,24(241)-dien-3β-ol",single,8,9).
-bond("4α-hydroxymethyl-stigmasta-7,24(241)-dien-3β-ol",single,8,14). bond("4α-hydroxymethyl-stigmasta-7,24(241)-dien-3β-ol",single,9,10). bond("4α-hydroxymethyl-stigmasta-7,24(241)-dien-3β-ol",single,9,11).
-bond("4α-hydroxymethyl-stigmasta-7,24(241)-dien-3β-ol",singleR,10,19). bond("4α-hydroxymethyl-stigmasta-7,24(241)-dien-3β-ol",single,11,12). bond("4α-hydroxymethyl-stigmasta-7,24(241)-dien-3β-ol",single,12,13).
-bond("4α-hydroxymethyl-stigmasta-7,24(241)-dien-3β-ol",single,13,14). bond("4α-hydroxymethyl-stigmasta-7,24(241)-dien-3β-ol",single,14,15). bond("4α-hydroxymethyl-stigmasta-7,24(241)-dien-3β-ol",single,15,16).
-bond("4α-hydroxymethyl-stigmasta-7,24(241)-dien-3β-ol",single,16,17). bond("4α-hydroxymethyl-stigmasta-7,24(241)-dien-3β-ol",single,13,17). bond("4α-hydroxymethyl-stigmasta-7,24(241)-dien-3β-ol",singleR,13,18).
-bond("4α-hydroxymethyl-stigmasta-7,24(241)-dien-3β-ol",singleR,17,20). bond("4α-hydroxymethyl-stigmasta-7,24(241)-dien-3β-ol",singleS,20,21). bond("4α-hydroxymethyl-stigmasta-7,24(241)-dien-3β-ol",single,20,22).
-bond("4α-hydroxymethyl-stigmasta-7,24(241)-dien-3β-ol",single,22,23). bond("4α-hydroxymethyl-stigmasta-7,24(241)-dien-3β-ol",single,23,24). bond("4α-hydroxymethyl-stigmasta-7,24(241)-dien-3β-ol",double,24,241).
-bond("4α-hydroxymethyl-stigmasta-7,24(241)-dien-3β-ol",single,241,242). bond("4α-hydroxymethyl-stigmasta-7,24(241)-dien-3β-ol",single,24,25). bond("4α-hydroxymethyl-stigmasta-7,24(241)-dien-3β-ol",single,25,26).
-bond("4α-hydroxymethyl-stigmasta-7,24(241)-dien-3β-ol",single,25,27). bond("4α-hydroxymethyl-stigmasta-7,24(241)-dien-3β-ol",single,28,32).
+atom("(24E)-4α-carboxy-stigmasta-7,24(241)-dien-3β-ol",1..24,carb). atom("(24E)-4α-carboxy-stigmasta-7,24(241)-dien-3β-ol",241,carb). atom("(24E)-4α-carboxy-stigmasta-7,24(241)-dien-3β-ol",242,carb).
+atom("(24E)-4α-carboxy-stigmasta-7,24(241)-dien-3β-ol",25..28,carb). atom("(24E)-4α-carboxy-stigmasta-7,24(241)-dien-3β-ol",31..33,oxyg).
+bond("(24E)-4α-carboxy-stigmasta-7,24(241)-dien-3β-ol",single,1,2). bond("(24E)-4α-carboxy-stigmasta-7,24(241)-dien-3β-ol",single,1,10). bond("(24E)-4α-carboxy-stigmasta-7,24(241)-dien-3β-ol",single,2,3).
+bond("(24E)-4α-carboxy-stigmasta-7,24(241)-dien-3β-ol",single,3,4). bond("(24E)-4α-carboxy-stigmasta-7,24(241)-dien-3β-ol",singleR,3,31). bond("(24E)-4α-carboxy-stigmasta-7,24(241)-dien-3β-ol",single,4,5).
+bond("(24E)-4α-carboxy-stigmasta-7,24(241)-dien-3β-ol",singleS,4,28). bond("(24E)-4α-carboxy-stigmasta-7,24(241)-dien-3β-ol",single,5,6). bond("(24E)-4α-carboxy-stigmasta-7,24(241)-dien-3β-ol",single,5,10).
+bond("(24E)-4α-carboxy-stigmasta-7,24(241)-dien-3β-ol",single,6,7). bond("(24E)-4α-carboxy-stigmasta-7,24(241)-dien-3β-ol",double,7,8). bond("(24E)-4α-carboxy-stigmasta-7,24(241)-dien-3β-ol",single,8,9).
+bond("(24E)-4α-carboxy-stigmasta-7,24(241)-dien-3β-ol",single,8,14). bond("(24E)-4α-carboxy-stigmasta-7,24(241)-dien-3β-ol",single,9,10). bond("(24E)-4α-carboxy-stigmasta-7,24(241)-dien-3β-ol",single,9,11).
+bond("(24E)-4α-carboxy-stigmasta-7,24(241)-dien-3β-ol",singleR,10,19). bond("(24E)-4α-carboxy-stigmasta-7,24(241)-dien-3β-ol",single,11,12). bond("(24E)-4α-carboxy-stigmasta-7,24(241)-dien-3β-ol",single,12,13).
+bond("(24E)-4α-carboxy-stigmasta-7,24(241)-dien-3β-ol",single,13,14). bond("(24E)-4α-carboxy-stigmasta-7,24(241)-dien-3β-ol",single,14,15). bond("(24E)-4α-carboxy-stigmasta-7,24(241)-dien-3β-ol",single,15,16).
+bond("(24E)-4α-carboxy-stigmasta-7,24(241)-dien-3β-ol",single,16,17). bond("(24E)-4α-carboxy-stigmasta-7,24(241)-dien-3β-ol",single,13,17). bond("(24E)-4α-carboxy-stigmasta-7,24(241)-dien-3β-ol",singleR,13,18).
+bond("(24E)-4α-carboxy-stigmasta-7,24(241)-dien-3β-ol",singleR,17,20). bond("(24E)-4α-carboxy-stigmasta-7,24(241)-dien-3β-ol",singleS,20,21). bond("(24E)-4α-carboxy-stigmasta-7,24(241)-dien-3β-ol",single,20,22).
+bond("(24E)-4α-carboxy-stigmasta-7,24(241)-dien-3β-ol",single,22,23). bond("(24E)-4α-carboxy-stigmasta-7,24(241)-dien-3β-ol",single,23,24). bond("(24E)-4α-carboxy-stigmasta-7,24(241)-dien-3β-ol",doubleE,24,241).
+bond("(24E)-4α-carboxy-stigmasta-7,24(241)-dien-3β-ol",single,241,242). bond("(24E)-4α-carboxy-stigmasta-7,24(241)-dien-3β-ol",single,24,25). bond("(24E)-4α-carboxy-stigmasta-7,24(241)-dien-3β-ol",single,25,26).
+bond("(24E)-4α-carboxy-stigmasta-7,24(241)-dien-3β-ol",single,25,27). bond("(24E)-4α-carboxy-stigmasta-7,24(241)-dien-3β-ol",double,28,32). bond("(24E)-4α-carboxy-stigmasta-7,24(241)-dien-3β-ol",single,28,33).
 
-atom("4α-formyl-stigmasta-7,24(241)-dien-3β-ol",1..24,carb). atom("4α-formyl-stigmasta-7,24(241)-dien-3β-ol",241,carb). atom("4α-formyl-stigmasta-7,24(241)-dien-3β-ol",242,carb).
-atom("4α-formyl-stigmasta-7,24(241)-dien-3β-ol",25..28,carb). atom("4α-formyl-stigmasta-7,24(241)-dien-3β-ol",31..32,oxyg).
-bond("4α-formyl-stigmasta-7,24(241)-dien-3β-ol",single,1,2). bond("4α-formyl-stigmasta-7,24(241)-dien-3β-ol",single,1,10). bond("4α-formyl-stigmasta-7,24(241)-dien-3β-ol",single,2,3).
-bond("4α-formyl-stigmasta-7,24(241)-dien-3β-ol",single,3,4). bond("4α-formyl-stigmasta-7,24(241)-dien-3β-ol",singleR,3,31). bond("4α-formyl-stigmasta-7,24(241)-dien-3β-ol",single,4,5).
-bond("4α-formyl-stigmasta-7,24(241)-dien-3β-ol",singleS,4,28). bond("4α-formyl-stigmasta-7,24(241)-dien-3β-ol",single,5,6). bond("4α-formyl-stigmasta-7,24(241)-dien-3β-ol",single,5,10).
-bond("4α-formyl-stigmasta-7,24(241)-dien-3β-ol",single,6,7). bond("4α-formyl-stigmasta-7,24(241)-dien-3β-ol",double,7,8). bond("4α-formyl-stigmasta-7,24(241)-dien-3β-ol",single,8,9).
-bond("4α-formyl-stigmasta-7,24(241)-dien-3β-ol",single,8,14). bond("4α-formyl-stigmasta-7,24(241)-dien-3β-ol",single,9,10). bond("4α-formyl-stigmasta-7,24(241)-dien-3β-ol",single,9,11).
-bond("4α-formyl-stigmasta-7,24(241)-dien-3β-ol",singleR,10,19). bond("4α-formyl-stigmasta-7,24(241)-dien-3β-ol",single,11,12). bond("4α-formyl-stigmasta-7,24(241)-dien-3β-ol",single,12,13).
-bond("4α-formyl-stigmasta-7,24(241)-dien-3β-ol",single,13,14). bond("4α-formyl-stigmasta-7,24(241)-dien-3β-ol",single,14,15). bond("4α-formyl-stigmasta-7,24(241)-dien-3β-ol",single,15,16).
-bond("4α-formyl-stigmasta-7,24(241)-dien-3β-ol",single,16,17). bond("4α-formyl-stigmasta-7,24(241)-dien-3β-ol",single,13,17). bond("4α-formyl-stigmasta-7,24(241)-dien-3β-ol",singleR,13,18).
-bond("4α-formyl-stigmasta-7,24(241)-dien-3β-ol",singleR,17,20). bond("4α-formyl-stigmasta-7,24(241)-dien-3β-ol",singleS,20,21). bond("4α-formyl-stigmasta-7,24(241)-dien-3β-ol",single,20,22).
-bond("4α-formyl-stigmasta-7,24(241)-dien-3β-ol",single,22,23). bond("4α-formyl-stigmasta-7,24(241)-dien-3β-ol",single,23,24). bond("4α-formyl-stigmasta-7,24(241)-dien-3β-ol",double,24,241).
-bond("4α-formyl-stigmasta-7,24(241)-dien-3β-ol",single,241,242). bond("4α-formyl-stigmasta-7,24(241)-dien-3β-ol",single,24,25). bond("4α-formyl-stigmasta-7,24(241)-dien-3β-ol",single,25,26).
-bond("4α-formyl-stigmasta-7,24(241)-dien-3β-ol",single,25,27). bond("4α-formyl-stigmasta-7,24(241)-dien-3β-ol",double,28,32).
+atom("isoavenastenone",1..24,carb). atom("isoavenastenone",241,carb). atom("isoavenastenone",242,carb).
+atom("isoavenastenone",25..27,carb). atom("isoavenastenone",31,oxyg).
+bond("isoavenastenone",single,1,2). bond("isoavenastenone",single,1,10). bond("isoavenastenone",single,2,3).
+bond("isoavenastenone",single,3,4). bond("isoavenastenone",double,3,31). bond("isoavenastenone",single,4,5).
+bond("isoavenastenone",single,5,6). bond("isoavenastenone",single,5,10). bond("isoavenastenone",single,6,7).
+bond("isoavenastenone",double,7,8). bond("isoavenastenone",single,8,9). bond("isoavenastenone",single,8,14).
+bond("isoavenastenone",single,9,10). bond("isoavenastenone",single,9,11). bond("isoavenastenone",singleR,10,19).
+bond("isoavenastenone",single,11,12). bond("isoavenastenone",single,12,13). bond("isoavenastenone",single,13,14).
+bond("isoavenastenone",single,14,15). bond("isoavenastenone",single,15,16). bond("isoavenastenone",single,16,17).
+bond("isoavenastenone",single,13,17). bond("isoavenastenone",singleR,13,18). bond("isoavenastenone",singleR,17,20).
+bond("isoavenastenone",singleS,20,21). bond("isoavenastenone",single,20,22). bond("isoavenastenone",single,22,23).
+bond("isoavenastenone",single,23,24). bond("isoavenastenone",doubleE,24,241). bond("isoavenastenone",single,241,242).
+bond("isoavenastenone",single,24,25). bond("isoavenastenone",single,25,26). bond("isoavenastenone",single,25,27).
 
-atom("4α-carboxy-stigmasta-7,24(241)-dien-3β-ol",1..24,carb). atom("4α-carboxy-stigmasta-7,24(241)-dien-3β-ol",241,carb). atom("4α-carboxy-stigmasta-7,24(241)-dien-3β-ol",242,carb).
-atom("4α-carboxy-stigmasta-7,24(241)-dien-3β-ol",25..28,carb). atom("4α-carboxy-stigmasta-7,24(241)-dien-3β-ol",31..33,oxyg).
-bond("4α-carboxy-stigmasta-7,24(241)-dien-3β-ol",single,1,2). bond("4α-carboxy-stigmasta-7,24(241)-dien-3β-ol",single,1,10). bond("4α-carboxy-stigmasta-7,24(241)-dien-3β-ol",single,2,3).
-bond("4α-carboxy-stigmasta-7,24(241)-dien-3β-ol",single,3,4). bond("4α-carboxy-stigmasta-7,24(241)-dien-3β-ol",singleR,3,31). bond("4α-carboxy-stigmasta-7,24(241)-dien-3β-ol",single,4,5).
-bond("4α-carboxy-stigmasta-7,24(241)-dien-3β-ol",singleS,4,28). bond("4α-carboxy-stigmasta-7,24(241)-dien-3β-ol",single,5,6). bond("4α-carboxy-stigmasta-7,24(241)-dien-3β-ol",single,5,10).
-bond("4α-carboxy-stigmasta-7,24(241)-dien-3β-ol",single,6,7). bond("4α-carboxy-stigmasta-7,24(241)-dien-3β-ol",double,7,8). bond("4α-carboxy-stigmasta-7,24(241)-dien-3β-ol",single,8,9).
-bond("4α-carboxy-stigmasta-7,24(241)-dien-3β-ol",single,8,14). bond("4α-carboxy-stigmasta-7,24(241)-dien-3β-ol",single,9,10). bond("4α-carboxy-stigmasta-7,24(241)-dien-3β-ol",single,9,11).
-bond("4α-carboxy-stigmasta-7,24(241)-dien-3β-ol",singleR,10,19). bond("4α-carboxy-stigmasta-7,24(241)-dien-3β-ol",single,11,12). bond("4α-carboxy-stigmasta-7,24(241)-dien-3β-ol",single,12,13).
-bond("4α-carboxy-stigmasta-7,24(241)-dien-3β-ol",single,13,14). bond("4α-carboxy-stigmasta-7,24(241)-dien-3β-ol",single,14,15). bond("4α-carboxy-stigmasta-7,24(241)-dien-3β-ol",single,15,16).
-bond("4α-carboxy-stigmasta-7,24(241)-dien-3β-ol",single,16,17). bond("4α-carboxy-stigmasta-7,24(241)-dien-3β-ol",single,13,17). bond("4α-carboxy-stigmasta-7,24(241)-dien-3β-ol",singleR,13,18).
-bond("4α-carboxy-stigmasta-7,24(241)-dien-3β-ol",singleR,17,20). bond("4α-carboxy-stigmasta-7,24(241)-dien-3β-ol",singleS,20,21). bond("4α-carboxy-stigmasta-7,24(241)-dien-3β-ol",single,20,22).
-bond("4α-carboxy-stigmasta-7,24(241)-dien-3β-ol",single,22,23). bond("4α-carboxy-stigmasta-7,24(241)-dien-3β-ol",single,23,24). bond("4α-carboxy-stigmasta-7,24(241)-dien-3β-ol",double,24,241).
-bond("4α-carboxy-stigmasta-7,24(241)-dien-3β-ol",single,241,242). bond("4α-carboxy-stigmasta-7,24(241)-dien-3β-ol",single,24,25). bond("4α-carboxy-stigmasta-7,24(241)-dien-3β-ol",single,25,26).
-bond("4α-carboxy-stigmasta-7,24(241)-dien-3β-ol",single,25,27). bond("4α-carboxy-stigmasta-7,24(241)-dien-3β-ol",double,28,32). bond("4α-carboxy-stigmasta-7,24(241)-dien-3β-ol",single,28,33).
+atom("isoavenasterol",1..24,carb). atom("isoavenasterol",241,carb). atom("isoavenasterol",242,carb).
+atom("isoavenasterol",25..27,carb). atom("isoavenasterol",31,oxyg).
+bond("isoavenasterol",single,1,2). bond("isoavenasterol",single,1,10). bond("isoavenasterol",single,2,3).
+bond("isoavenasterol",single,3,4). bond("isoavenasterol",singleR,3,31). bond("isoavenasterol",single,4,5).
+bond("isoavenasterol",single,5,6). bond("isoavenasterol",single,5,10). bond("isoavenasterol",single,6,7).
+bond("isoavenasterol",double,7,8). bond("isoavenasterol",single,8,9). bond("isoavenasterol",single,8,14).
+bond("isoavenasterol",single,9,10). bond("isoavenasterol",single,9,11). bond("isoavenasterol",singleR,10,19).
+bond("isoavenasterol",single,11,12). bond("isoavenasterol",single,12,13). bond("isoavenasterol",single,13,14).
+bond("isoavenasterol",single,14,15). bond("isoavenasterol",single,15,16). bond("isoavenasterol",single,16,17).
+bond("isoavenasterol",single,13,17). bond("isoavenasterol",singleR,13,18). bond("isoavenasterol",singleR,17,20).
+bond("isoavenasterol",singleS,20,21). bond("isoavenasterol",single,20,22). bond("isoavenasterol",single,22,23).
+bond("isoavenasterol",single,23,24). bond("isoavenasterol",doubleE,24,241). bond("isoavenasterol",single,241,242).
+bond("isoavenasterol",single,24,25). bond("isoavenasterol",single,25,26). bond("isoavenasterol",single,25,27).
 
-atom("avenastenone",1..24,carb). atom("avenastenone",241,carb). atom("avenastenone",242,carb).
-atom("avenastenone",25..27,carb). atom("avenastenone",31,oxyg).
-bond("avenastenone",single,1,2). bond("avenastenone",single,1,10). bond("avenastenone",single,2,3).
-bond("avenastenone",single,3,4). bond("avenastenone",double,3,31). bond("avenastenone",single,4,5).
-bond("avenastenone",single,5,6). bond("avenastenone",single,5,10). bond("avenastenone",single,6,7).
-bond("avenastenone",double,7,8). bond("avenastenone",single,8,9). bond("avenastenone",single,8,14).
-bond("avenastenone",single,9,10). bond("avenastenone",single,9,11). bond("avenastenone",singleR,10,19).
-bond("avenastenone",single,11,12). bond("avenastenone",single,12,13). bond("avenastenone",single,13,14).
-bond("avenastenone",single,14,15). bond("avenastenone",single,15,16). bond("avenastenone",single,16,17).
-bond("avenastenone",single,13,17). bond("avenastenone",singleR,13,18). bond("avenastenone",singleR,17,20).
-bond("avenastenone",singleS,20,21). bond("avenastenone",single,20,22). bond("avenastenone",single,22,23).
-bond("avenastenone",single,23,24). bond("avenastenone",double,24,241). bond("avenastenone",single,241,242).
-bond("avenastenone",single,24,25). bond("avenastenone",single,25,26). bond("avenastenone",single,25,27).
-
-atom("avenasterol",1..24,carb). atom("avenasterol",241,carb). atom("avenasterol",242,carb).
-atom("avenasterol",25..27,carb). atom("avenasterol",31,oxyg).
-bond("avenasterol",single,1,2). bond("avenasterol",single,1,10). bond("avenasterol",single,2,3).
-bond("avenasterol",single,3,4). bond("avenasterol",singleR,3,31). bond("avenasterol",single,4,5).
-bond("avenasterol",single,5,6). bond("avenasterol",single,5,10). bond("avenasterol",single,6,7).
-bond("avenasterol",double,7,8). bond("avenasterol",single,8,9). bond("avenasterol",single,8,14).
-bond("avenasterol",single,9,10). bond("avenasterol",single,9,11). bond("avenasterol",singleR,10,19).
-bond("avenasterol",single,11,12). bond("avenasterol",single,12,13). bond("avenasterol",single,13,14).
-bond("avenasterol",single,14,15). bond("avenasterol",single,15,16). bond("avenasterol",single,16,17).
-bond("avenasterol",single,13,17). bond("avenasterol",singleR,13,18). bond("avenasterol",singleR,17,20).
-bond("avenasterol",singleS,20,21). bond("avenasterol",single,20,22). bond("avenasterol",single,22,23).
-bond("avenasterol",single,23,24). bond("avenasterol",double,24,241). bond("avenasterol",single,241,242).
-bond("avenasterol",single,24,25). bond("avenasterol",single,25,26). bond("avenasterol",single,25,27).
-
-atom("5-dehydroavenasterol",1..24,carb). atom("5-dehydroavenasterol",241,carb). atom("5-dehydroavenasterol",242,carb).
-atom("5-dehydroavenasterol",25..27,carb). atom("5-dehydroavenasterol",31,oxyg).
-bond("5-dehydroavenasterol",single,1,2). bond("5-dehydroavenasterol",single,1,10). bond("5-dehydroavenasterol",single,2,3).
-bond("5-dehydroavenasterol",single,3,4). bond("5-dehydroavenasterol",singleR,3,31). bond("5-dehydroavenasterol",single,4,5).
-bond("5-dehydroavenasterol",double,5,6). bond("5-dehydroavenasterol",single,5,10). bond("5-dehydroavenasterol",single,6,7).
-bond("5-dehydroavenasterol",double,7,8). bond("5-dehydroavenasterol",single,8,9). bond("5-dehydroavenasterol",single,8,14).
-bond("5-dehydroavenasterol",single,9,10). bond("5-dehydroavenasterol",single,9,11). bond("5-dehydroavenasterol",singleR,10,19).
-bond("5-dehydroavenasterol",single,11,12). bond("5-dehydroavenasterol",single,12,13). bond("5-dehydroavenasterol",single,13,14).
-bond("5-dehydroavenasterol",single,14,15). bond("5-dehydroavenasterol",single,15,16). bond("5-dehydroavenasterol",single,16,17).
-bond("5-dehydroavenasterol",single,13,17). bond("5-dehydroavenasterol",singleR,13,18). bond("5-dehydroavenasterol",singleR,17,20).
-bond("5-dehydroavenasterol",singleS,20,21). bond("5-dehydroavenasterol",single,20,22). bond("5-dehydroavenasterol",single,22,23).
-bond("5-dehydroavenasterol",single,23,24). bond("5-dehydroavenasterol",double,24,241). bond("5-dehydroavenasterol",single,241,242).
-bond("5-dehydroavenasterol",single,24,25). bond("5-dehydroavenasterol",single,25,26). bond("5-dehydroavenasterol",single,25,27).
+atom("5-dehydroisoavenasterol",1..24,carb). atom("5-dehydroisoavenasterol",241,carb). atom("5-dehydroisoavenasterol",242,carb).
+atom("5-dehydroisoavenasterol",25..27,carb). atom("5-dehydroisoavenasterol",31,oxyg).
+bond("5-dehydroisoavenasterol",single,1,2). bond("5-dehydroisoavenasterol",single,1,10). bond("5-dehydroisoavenasterol",single,2,3).
+bond("5-dehydroisoavenasterol",single,3,4). bond("5-dehydroisoavenasterol",singleR,3,31). bond("5-dehydroisoavenasterol",single,4,5).
+bond("5-dehydroisoavenasterol",double,5,6). bond("5-dehydroisoavenasterol",single,5,10). bond("5-dehydroisoavenasterol",single,6,7).
+bond("5-dehydroisoavenasterol",double,7,8). bond("5-dehydroisoavenasterol",single,8,9). bond("5-dehydroisoavenasterol",single,8,14).
+bond("5-dehydroisoavenasterol",single,9,10). bond("5-dehydroisoavenasterol",single,9,11). bond("5-dehydroisoavenasterol",singleR,10,19).
+bond("5-dehydroisoavenasterol",single,11,12). bond("5-dehydroisoavenasterol",single,12,13). bond("5-dehydroisoavenasterol",single,13,14).
+bond("5-dehydroisoavenasterol",single,14,15). bond("5-dehydroisoavenasterol",single,15,16). bond("5-dehydroisoavenasterol",single,16,17).
+bond("5-dehydroisoavenasterol",single,13,17). bond("5-dehydroisoavenasterol",singleR,13,18). bond("5-dehydroisoavenasterol",singleR,17,20).
+bond("5-dehydroisoavenasterol",singleS,20,21). bond("5-dehydroisoavenasterol",single,20,22). bond("5-dehydroisoavenasterol",single,22,23).
+bond("5-dehydroisoavenasterol",single,23,24). bond("5-dehydroisoavenasterol",doubleE,24,241). bond("5-dehydroisoavenasterol",single,241,242).
+bond("5-dehydroisoavenasterol",single,24,25). bond("5-dehydroisoavenasterol",single,25,26). bond("5-dehydroisoavenasterol",single,25,27).
 
 atom("fucosterol",1..24,carb). atom("fucosterol",241,carb). atom("fucosterol",242,carb).
 atom("fucosterol",25..27,carb). atom("fucosterol",31,oxyg).
@@ -350,7 +320,7 @@ bond("fucosterol",single,11,12). bond("fucosterol",single,12,13). bond("fucoster
 bond("fucosterol",single,14,15). bond("fucosterol",single,15,16). bond("fucosterol",single,16,17).
 bond("fucosterol",single,13,17). bond("fucosterol",singleR,13,18). bond("fucosterol",singleR,17,20).
 bond("fucosterol",singleS,20,21). bond("fucosterol",single,20,22). bond("fucosterol",single,22,23).
-bond("fucosterol",single,23,24). bond("fucosterol",double,24,241). bond("fucosterol",single,241,242).
+bond("fucosterol",single,23,24). bond("fucosterol",doubleE,24,241). bond("fucosterol",single,241,242).
 bond("fucosterol",single,24,25). bond("fucosterol",single,25,26). bond("fucosterol",single,25,27).
 
 % episterol branch
@@ -796,7 +766,13 @@ reaction(rxn_2_1_1_143,"24-methylenelophenol","24-ethylidenelophenol").
 reaction(rxn_20131,"24-methylenecholesterol","campesterol").
 reaction(c22_desaturation,"campesterol","brassicasterol").
 
-
+%PWY-8238
+reaction(rxn_22199,"24-methylenelophenol","24-ethylenelophenol").
+reaction(rxn_22203,"24-ethylenelophenol","(24E)-4α-carboxy-stigmasta-7,24(241)-dien-3β-ol").
+reactions(rxn_22204,"(24E)-4α-carboxy-stigmasta-7,24(241)-dien-3β-ol","isoavenasterone").
+reaction(rxn_22205,"isoavenasterone","isoavenasterol").
+reaction(rxn_22206,"isoavenasterol","5-dehydroavenasterol").
+reaction(rxn_22198,"5-dehydroavenasterol","fucosterol").
 
 % Molecules absent in the organism.
 

--- a/pathmodel/data/brown_sterols_pwy.lp
+++ b/pathmodel/data/brown_sterols_pwy.lp
@@ -747,10 +747,10 @@ reaction(rxn_11934,"episterone","episterol").
 reaction(rxn3o_218,"episterol","ergosta-5,7,24(28)-trien-3β-ol").
 reaction(rxn_707,"ergosta-5,7,24(28)-trien-3β-ol","24-methylenecholesterol").
 reaction(rxn_4222,"24-methylenecholesterol","24-methyldesmosterol").
-reaction(rxn_708,"24-methyldesmosterol","campesterol").
+reaction(rxn_708,"24-methyldesmosterol","24-methylcholesterol").
 reaction(rxn_2_1_1_143,"24-methylenelophenol","24-ethylidenelophenol").
-reaction(rxn_20131,"24-methylenecholesterol","campesterol").
-reaction(c22_desaturation,"campesterol","brassicasterol").
+reaction(rxn_20131,"24-methylenecholesterol","24-methylcholesterol").
+reaction(c22_desaturation,"24-methylcholesterol","24-methylcholest-22-enol").
 
 %PWY-8238
 reaction(rxn_22199,"24-methylenelophenol","24-ethylenelophenol").

--- a/pathmodel/data/brown_sterols_pwy.lp
+++ b/pathmodel/data/brown_sterols_pwy.lp
@@ -235,21 +235,6 @@ bond("24-methylenelophenol",singleR,17,20). bond("24-methylenelophenol",singleS,
 bond("24-methylenelophenol",single,22,23). bond("24-methylenelophenol",single,23,24). bond("24-methylenelophenol",double,24,241).
 bond("24-methylenelophenol",single,24,25). bond("24-methylenelophenol",single,25,26). bond("24-methylenelophenol",single,25,27).
 
-atom("24-ethylenelophenol",1..24,carb). atom("24-ethylenelophenol",241,carb).  atom("24-ethylenelophenol",242,carb).
-atom("24-ethylenelophenol",25..28,carb). atom("24-ethylenelophenol",31,oxyg).
-bond("24-ethylenelophenol",single,1,2). bond("24-ethylenelophenol",single,1,10). bond("24-ethylenelophenol",single,2,3).
-bond("24-ethylenelophenol",single,3,4). bond("24-ethylenelophenol",singleR,3,31). bond("24-ethylenelophenol",single,4,5).
-bond("24-ethylenelophenol",singleS,4,28). bond("24-ethylenelophenol",single,5,6). bond("24-ethylenelophenol",single,5,10).
-bond("24-ethylenelophenol",single,6,7). bond("24-ethylenelophenol",double,7,8). bond("24-ethylenelophenol",single,8,9).
-bond("24-ethylenelophenol",single,8,14). bond("24-ethylenelophenol",single,9,10). bond("24-ethylenelophenol",single,9,11).
-bond("24-ethylenelophenol",singleR,10,19). bond("24-ethylenelophenol",single,11,12). bond("24-ethylenelophenol",single,12,13).
-bond("24-ethylenelophenol",single,13,14). bond("24-ethylenelophenol",single,14,15). bond("24-ethylenelophenol",single,15,16).
-bond("24-ethylenelophenol",single,16,17). bond("24-ethylenelophenol",single,13,17). bond("24-ethylenelophenol",singleR,13,18).
-bond("24-ethylenelophenol",singleR,17,20). bond("24-ethylenelophenol",singleS,20,21). bond("24-ethylenelophenol",single,20,22).
-bond("24-ethylenelophenol",single,22,23). bond("24-ethylenelophenol",single,23,24). bond("24-ethylenelophenol",double,24,241).
-bond("24-ethylenelophenol",single,24,25). bond("24-ethylenelophenol",single,241,242). bond("24-ethylenelophenol",single,25,26).
-bond("24-ethylenelophenol",single,25,27).
-
 % 24-ethylidenelophenol branch
 
 atom("24-ethylidenelophenol",1..24,carb). atom("24-ethylidenelophenol",241,carb). atom("24-ethylidenelophenol",242,carb).
@@ -781,8 +766,6 @@ reaction(rxn_11936,"4α-hydroxymethyl-stigmasta-7,24(241)-dien-3β-ol","4α-form
 reaction(rxn_11937,"4α-formyl-stigmasta-7,24(241)-dien-3β-ol","4α-carboxy-stigmasta-7,24(241)-dien-3β-ol").
 reaction(rxn_11938,"4α-carboxy-stigmasta-7,24(241)-dien-3β-ol","avenastenone").
 reaction(rxn_11939,"avenastenone","avenasterol").
-reaction(c28_methylation,"24-methylenelophenol","24-ethylenelophenol").
-reaction(c4_demethylation,"24-ethylenelophenol","avenasterol").
 reaction(rxn_4209,"avenasterol","5-dehydroavenasterol").
 reaction(rxn_4210,"5-dehydroavenasterol","fucosterol").
 reaction(rxn_11930,"24-methylenelophenol","4α-hydroxymethyl-ergosta-7,24(241)-dien-3β-ol").

--- a/pathmodel/data/brown_sterols_pwy.lp
+++ b/pathmodel/data/brown_sterols_pwy.lp
@@ -1,0 +1,791 @@
+%*This is work in progress for a paper by Girard et al., to be submitted to Frontiers in Plant Science, and has not yet been peer reviewed. 
+*%
+
+%*
+Data
+Describing the starting set of metabolites
+
+atom(Compound name, Atom number, Atom type).
+bond(Compound name, Chemical bond type, Atom number1, Greater Atom number2).
+*%
+
+% Sterol from PWY-2541
+
+atom("cycloartenol",1..30,carb). atom("cycloartenol",31,oxyg).
+bond("cycloartenol",single,1,2). bond("cycloartenol",single,1,10). bond("cycloartenol",single,2,3).
+bond("cycloartenol",single,3,4). bond("cycloartenol",singleR,3,31). bond("cycloartenol",single,4,5).
+bond("cycloartenol",singleR,4,29). bond("cycloartenol",singleS,4,28). bond("cycloartenol",single,5,6).
+bond("cycloartenol",single,5,10). bond("cycloartenol",single,6,7). bond("cycloartenol",single,7,8).
+bond("cycloartenol",single,8,9). bond("cycloartenol",single,8,14). bond("cycloartenol",single,9,10).
+bond("cycloartenol",single,9,11). bond("cycloartenol",singleR,9,19). bond("cycloartenol",singleR,10,19).
+bond("cycloartenol",single,11,12). bond("cycloartenol",single,12,13). bond("cycloartenol",single,13,14).
+bond("cycloartenol",single,14,15). bond("cycloartenol",singleS,14,30). bond("cycloartenol",single,15,16).
+bond("cycloartenol",single,16,17). bond("cycloartenol",single,13,17). bond("cycloartenol",singleR,13,18).
+bond("cycloartenol",singleR,17,20). bond("cycloartenol",singleS,20,21). bond("cycloartenol",single,20,22).
+bond("cycloartenol",single,22,23). bond("cycloartenol",single,23,24). bond("cycloartenol",double,24,25).
+bond("cycloartenol",single,25,26). bond("cycloartenol",single,25,27).
+
+atom("stigmasterol",1..24,carb). atom("stigmasterol",241,carb). atom("stigmasterol",242,carb).
+atom("stigmasterol",25..27,carb). atom("stigmasterol",31,oxyg).
+bond("stigmasterol",single,1,2). bond("stigmasterol",single,1,10). bond("stigmasterol",single,2,3).
+bond("stigmasterol",single,3,4). bond("stigmasterol",singleR,3,31). bond("stigmasterol",single,4,5).
+bond("stigmasterol",double,5,6). bond("stigmasterol",single,5,10). bond("stigmasterol",single,6,7).
+bond("stigmasterol",single,7,8). bond("stigmasterol",single,8,9). bond("stigmasterol",single,8,14).
+bond("stigmasterol",single,9,10). bond("stigmasterol",single,9,11). bond("stigmasterol",singleR,10,19).
+bond("stigmasterol",single,11,12). bond("stigmasterol",single,12,13). bond("stigmasterol",single,13,14).
+bond("stigmasterol",single,14,15). bond("stigmasterol",single,15,16). bond("stigmasterol",single,16,17).
+bond("stigmasterol",single,13,17). bond("stigmasterol",singleR,13,18). bond("stigmasterol",singleR,17,20).
+bond("stigmasterol",singleS,20,21). bond("stigmasterol",single,20,22). bond("stigmasterol",double,22,23).
+bond("stigmasterol",single,23,24). bond("stigmasterol",singleR,24,241). bond("stigmasterol",single,241,242).
+bond("stigmasterol",single,24,25). bond("stigmasterol",single,25,26). bond("stigmasterol",single,25,27).
+
+
+atom("24-methylenecholesterol",1..24,carb). atom("24-methylenecholesterol",241,carb). atom("24-methylenecholesterol",25..27,carb).
+atom("24-methylenecholesterol",31,oxyg).
+bond("24-methylenecholesterol",single,1,2). bond("24-methylenecholesterol",single,1,10). bond("24-methylenecholesterol",single,2,3).
+bond("24-methylenecholesterol",single,3,4). bond("24-methylenecholesterol",singleR,3,31). bond("24-methylenecholesterol",single,4,5).
+bond("24-methylenecholesterol",double,5,6). bond("24-methylenecholesterol",single,5,10). bond("24-methylenecholesterol",single,6,7).
+bond("24-methylenecholesterol",single,7,8). bond("24-methylenecholesterol",single,8,9). bond("24-methylenecholesterol",single,8,14).
+bond("24-methylenecholesterol",single,9,10). bond("24-methylenecholesterol",single,9,11). bond("24-methylenecholesterol",singleR,10,19).
+bond("24-methylenecholesterol",single,11,12). bond("24-methylenecholesterol",single,12,13). bond("24-methylenecholesterol",single,13,14).
+bond("24-methylenecholesterol",single,14,15). bond("24-methylenecholesterol",single,15,16). bond("24-methylenecholesterol",single,16,17).
+bond("24-methylenecholesterol",single,13,17). bond("24-methylenecholesterol",singleR,13,18). bond("24-methylenecholesterol",singleR,17,20).
+bond("24-methylenecholesterol",singleS,20,21). bond("24-methylenecholesterol",single,20,22). bond("24-methylenecholesterol",single,22,23).
+bond("24-methylenecholesterol",single,23,24). bond("24-methylenecholesterol",double,24,241). bond("24-methylenecholesterol",single,24,25).
+bond("24-methylenecholesterol",single,25,26). bond("24-methylenecholesterol",single,25,27).
+
+
+atom("campesterol",1..24,carb). atom("campesterol",241,carb). atom("campesterol",25..27,carb).
+atom("campesterol",31,oxyg).
+bond("campesterol",single,1,2). bond("campesterol",single,1,10). bond("campesterol",single,2,3).
+bond("campesterol",single,3,4). bond("campesterol",singleR,3,31). bond("campesterol",single,4,5).
+bond("campesterol",double,5,6). bond("campesterol",single,5,10). bond("campesterol",single,6,7).
+bond("campesterol",single,7,8). bond("campesterol",single,8,9). bond("campesterol",single,8,14).
+bond("campesterol",single,9,10). bond("campesterol",single,9,11). bond("campesterol",singleR,10,19).
+bond("campesterol",single,11,12). bond("campesterol",single,12,13). bond("campesterol",single,13,14).
+bond("campesterol",single,14,15). bond("campesterol",single,15,16). bond("campesterol",single,16,17).
+bond("campesterol",single,13,17). bond("campesterol",singleR,13,18). bond("campesterol",singleR,17,20).
+bond("campesterol",singleS,20,21). bond("campesterol",single,20,22). bond("campesterol",single,22,23).
+bond("campesterol",single,23,24). bond("campesterol",singleR,24,241). bond("campesterol",single,24,25).
+bond("campesterol",single,25,26). bond("campesterol",single,25,27).
+
+
+atom("brassicasterol",1..24,carb). atom("brassicasterol",241,carb). atom("brassicasterol",25..27,carb).
+atom("brassicasterol",31,oxyg).
+bond("brassicasterol",single,1,2). bond("brassicasterol",single,1,10). bond("brassicasterol",single,2,3).
+bond("brassicasterol",single,3,4). bond("brassicasterol",singleR,3,31). bond("brassicasterol",single,4,5).
+bond("brassicasterol",double,5,6). bond("brassicasterol",single,5,10). bond("brassicasterol",single,6,7).
+bond("brassicasterol",single,7,8). bond("brassicasterol",single,8,9). bond("brassicasterol",single,8,14).
+bond("brassicasterol",single,9,10). bond("brassicasterol",single,9,11). bond("brassicasterol",singleR,10,19).
+bond("brassicasterol",single,11,12). bond("brassicasterol",single,12,13). bond("brassicasterol",single,13,14).
+bond("brassicasterol",single,14,15). bond("brassicasterol",single,15,16). bond("brassicasterol",single,16,17).
+bond("brassicasterol",single,13,17). bond("brassicasterol",singleR,13,18). bond("brassicasterol",singleR,17,20).
+bond("brassicasterol",singleS,20,21). bond("brassicasterol",single,20,22). bond("brassicasterol",double,22,23).
+bond("brassicasterol",single,23,24). bond("brassicasterol",singleR,24,241). bond("brassicasterol",single,24,25).
+bond("brassicasterol",single,25,26). bond("brassicasterol",single,25,27).
+
+
+atom("24-methylenecycloartanol",1..24,carb). atom("24-methylenecycloartanol",241,carb). atom("24-methylenecycloartanol",25..30,carb).
+atom("24-methylenecycloartanol",31,oxyg).
+bond("24-methylenecycloartanol",single,1,2). bond("24-methylenecycloartanol",single,1,10). bond("24-methylenecycloartanol",single,2,3).
+bond("24-methylenecycloartanol",single,3,4). bond("24-methylenecycloartanol",singleR,3,31). bond("24-methylenecycloartanol",single,4,5).
+bond("24-methylenecycloartanol",singleR,4,29). bond("24-methylenecycloartanol",singleS,4,28). bond("24-methylenecycloartanol",single,5,6).
+bond("24-methylenecycloartanol",single,5,10). bond("24-methylenecycloartanol",single,6,7). bond("24-methylenecycloartanol",single,7,8).
+bond("24-methylenecycloartanol",single,8,9). bond("24-methylenecycloartanol",single,8,14). bond("24-methylenecycloartanol",single,9,10).
+bond("24-methylenecycloartanol",single,9,11).bond("24-methylenecycloartanol",singleR,9,19). bond("24-methylenecycloartanol",singleR,10,19).
+bond("24-methylenecycloartanol",single,11,12). bond("24-methylenecycloartanol",single,12,13). bond("24-methylenecycloartanol",single,13,14).
+bond("24-methylenecycloartanol",single,14,15). bond("24-methylenecycloartanol",singleS,14,30). bond("24-methylenecycloartanol",single,15,16).
+bond("24-methylenecycloartanol",single,16,17). bond("24-methylenecycloartanol",single,13,17). bond("24-methylenecycloartanol",singleR,13,18).
+bond("24-methylenecycloartanol",singleR,17,20). bond("24-methylenecycloartanol",singleS,20,21). bond("24-methylenecycloartanol",single,20,22).
+bond("24-methylenecycloartanol",single,22,23). bond("24-methylenecycloartanol",single,23,24). bond("24-methylenecycloartanol",double,24,241).
+bond("24-methylenecycloartanol",single,24,25). bond("24-methylenecycloartanol",single,25,26). bond("24-methylenecycloartanol",single,25,27).
+
+atom("4α-hydroxymethyl,4β,14α-dimethyl-9β,19-cyclo-5α-ergost-24(241)-en-3β-ol",1..24,carb). atom("4α-hydroxymethyl,4β,14α-dimethyl-9β,19-cyclo-5α-ergost-24(241)-en-3β-ol",241,carb). atom("4α-hydroxymethyl,4β,14α-dimethyl-9β,19-cyclo-5α-ergost-24(241)-en-3β-ol",25..30,carb).
+atom("4α-hydroxymethyl,4β,14α-dimethyl-9β,19-cyclo-5α-ergost-24(241)-en-3β-ol",31,oxyg). atom("4α-hydroxymethyl,4β,14α-dimethyl-9β,19-cyclo-5α-ergost-24(241)-en-3β-ol",32,oxyg).
+bond("4α-hydroxymethyl,4β,14α-dimethyl-9β,19-cyclo-5α-ergost-24(241)-en-3β-ol",single,1,2). bond("4α-hydroxymethyl,4β,14α-dimethyl-9β,19-cyclo-5α-ergost-24(241)-en-3β-ol",single,1,10). bond("4α-hydroxymethyl,4β,14α-dimethyl-9β,19-cyclo-5α-ergost-24(241)-en-3β-ol",single,2,3).
+bond("4α-hydroxymethyl,4β,14α-dimethyl-9β,19-cyclo-5α-ergost-24(241)-en-3β-ol",single,3,4). bond("4α-hydroxymethyl,4β,14α-dimethyl-9β,19-cyclo-5α-ergost-24(241)-en-3β-ol",singleR,3,31). bond("4α-hydroxymethyl,4β,14α-dimethyl-9β,19-cyclo-5α-ergost-24(241)-en-3β-ol",single,4,5).
+bond("4α-hydroxymethyl,4β,14α-dimethyl-9β,19-cyclo-5α-ergost-24(241)-en-3β-ol",singleR,4,29). bond("4α-hydroxymethyl,4β,14α-dimethyl-9β,19-cyclo-5α-ergost-24(241)-en-3β-ol",singleS,4,28). bond("4α-hydroxymethyl,4β,14α-dimethyl-9β,19-cyclo-5α-ergost-24(241)-en-3β-ol",single,5,6).
+bond("4α-hydroxymethyl,4β,14α-dimethyl-9β,19-cyclo-5α-ergost-24(241)-en-3β-ol",single,5,10). bond("4α-hydroxymethyl,4β,14α-dimethyl-9β,19-cyclo-5α-ergost-24(241)-en-3β-ol",single,6,7). bond("4α-hydroxymethyl,4β,14α-dimethyl-9β,19-cyclo-5α-ergost-24(241)-en-3β-ol",single,7,8).
+bond("4α-hydroxymethyl,4β,14α-dimethyl-9β,19-cyclo-5α-ergost-24(241)-en-3β-ol",single,8,9). bond("4α-hydroxymethyl,4β,14α-dimethyl-9β,19-cyclo-5α-ergost-24(241)-en-3β-ol",single,8,14). bond("4α-hydroxymethyl,4β,14α-dimethyl-9β,19-cyclo-5α-ergost-24(241)-en-3β-ol",single,9,10).
+bond("4α-hydroxymethyl,4β,14α-dimethyl-9β,19-cyclo-5α-ergost-24(241)-en-3β-ol",single,9,11).bond("4α-hydroxymethyl,4β,14α-dimethyl-9β,19-cyclo-5α-ergost-24(241)-en-3β-ol",singleR,9,19). bond("4α-hydroxymethyl,4β,14α-dimethyl-9β,19-cyclo-5α-ergost-24(241)-en-3β-ol",singleR,10,19).
+bond("4α-hydroxymethyl,4β,14α-dimethyl-9β,19-cyclo-5α-ergost-24(241)-en-3β-ol",single,11,12). bond("4α-hydroxymethyl,4β,14α-dimethyl-9β,19-cyclo-5α-ergost-24(241)-en-3β-ol",single,12,13). bond("4α-hydroxymethyl,4β,14α-dimethyl-9β,19-cyclo-5α-ergost-24(241)-en-3β-ol",single,13,14).
+bond("4α-hydroxymethyl,4β,14α-dimethyl-9β,19-cyclo-5α-ergost-24(241)-en-3β-ol",single,14,15). bond("4α-hydroxymethyl,4β,14α-dimethyl-9β,19-cyclo-5α-ergost-24(241)-en-3β-ol",singleS,14,30). bond("4α-hydroxymethyl,4β,14α-dimethyl-9β,19-cyclo-5α-ergost-24(241)-en-3β-ol",single,15,16).
+bond("4α-hydroxymethyl,4β,14α-dimethyl-9β,19-cyclo-5α-ergost-24(241)-en-3β-ol",single,16,17). bond("4α-hydroxymethyl,4β,14α-dimethyl-9β,19-cyclo-5α-ergost-24(241)-en-3β-ol",single,13,17). bond("4α-hydroxymethyl,4β,14α-dimethyl-9β,19-cyclo-5α-ergost-24(241)-en-3β-ol",singleR,13,18).
+bond("4α-hydroxymethyl,4β,14α-dimethyl-9β,19-cyclo-5α-ergost-24(241)-en-3β-ol",singleR,17,20). bond("4α-hydroxymethyl,4β,14α-dimethyl-9β,19-cyclo-5α-ergost-24(241)-en-3β-ol",singleS,20,21). bond("4α-hydroxymethyl,4β,14α-dimethyl-9β,19-cyclo-5α-ergost-24(241)-en-3β-ol",single,20,22).
+bond("4α-hydroxymethyl,4β,14α-dimethyl-9β,19-cyclo-5α-ergost-24(241)-en-3β-ol",single,22,23). bond("4α-hydroxymethyl,4β,14α-dimethyl-9β,19-cyclo-5α-ergost-24(241)-en-3β-ol",single,23,24). bond("4α-hydroxymethyl,4β,14α-dimethyl-9β,19-cyclo-5α-ergost-24(241)-en-3β-ol",double,24,241).
+bond("4α-hydroxymethyl,4β,14α-dimethyl-9β,19-cyclo-5α-ergost-24(241)-en-3β-ol",single,24,25). bond("4α-hydroxymethyl,4β,14α-dimethyl-9β,19-cyclo-5α-ergost-24(241)-en-3β-ol",single,25,26). bond("4α-hydroxymethyl,4β,14α-dimethyl-9β,19-cyclo-5α-ergost-24(241)-en-3β-ol",single,25,27).
+bond("4α-hydroxymethyl,4β,14α-dimethyl-9β,19-cyclo-5α-ergost-24(241)-en-3β-ol",single,28,32).
+
+atom("4α-formyl,4β,14α-dimethyl-9β,19-cyclo-5α-ergost-24(241)-en-3β-ol",1..24,carb). atom("4α-formyl,4β,14α-dimethyl-9β,19-cyclo-5α-ergost-24(241)-en-3β-ol",241,carb). atom("4α-formyl,4β,14α-dimethyl-9β,19-cyclo-5α-ergost-24(241)-en-3β-ol",25..30,carb).
+atom("4α-formyl,4β,14α-dimethyl-9β,19-cyclo-5α-ergost-24(241)-en-3β-ol",31,oxyg). atom("4α-formyl,4β,14α-dimethyl-9β,19-cyclo-5α-ergost-24(241)-en-3β-ol",32,oxyg).
+bond("4α-formyl,4β,14α-dimethyl-9β,19-cyclo-5α-ergost-24(241)-en-3β-ol",single,1,2). bond("4α-formyl,4β,14α-dimethyl-9β,19-cyclo-5α-ergost-24(241)-en-3β-ol",single,1,10). bond("4α-formyl,4β,14α-dimethyl-9β,19-cyclo-5α-ergost-24(241)-en-3β-ol",single,2,3).
+bond("4α-formyl,4β,14α-dimethyl-9β,19-cyclo-5α-ergost-24(241)-en-3β-ol",single,3,4). bond("4α-formyl,4β,14α-dimethyl-9β,19-cyclo-5α-ergost-24(241)-en-3β-ol",singleR,3,31). bond("4α-formyl,4β,14α-dimethyl-9β,19-cyclo-5α-ergost-24(241)-en-3β-ol",single,4,5).
+bond("4α-formyl,4β,14α-dimethyl-9β,19-cyclo-5α-ergost-24(241)-en-3β-ol",singleR,4,29). bond("4α-formyl,4β,14α-dimethyl-9β,19-cyclo-5α-ergost-24(241)-en-3β-ol",singleS,4,28). bond("4α-formyl,4β,14α-dimethyl-9β,19-cyclo-5α-ergost-24(241)-en-3β-ol",single,5,6).
+bond("4α-formyl,4β,14α-dimethyl-9β,19-cyclo-5α-ergost-24(241)-en-3β-ol",single,5,10). bond("4α-formyl,4β,14α-dimethyl-9β,19-cyclo-5α-ergost-24(241)-en-3β-ol",single,6,7). bond("4α-formyl,4β,14α-dimethyl-9β,19-cyclo-5α-ergost-24(241)-en-3β-ol",single,7,8).
+bond("4α-formyl,4β,14α-dimethyl-9β,19-cyclo-5α-ergost-24(241)-en-3β-ol",single,8,9). bond("4α-formyl,4β,14α-dimethyl-9β,19-cyclo-5α-ergost-24(241)-en-3β-ol",single,8,14). bond("4α-formyl,4β,14α-dimethyl-9β,19-cyclo-5α-ergost-24(241)-en-3β-ol",single,9,10).
+bond("4α-formyl,4β,14α-dimethyl-9β,19-cyclo-5α-ergost-24(241)-en-3β-ol",single,9,11).bond("4α-formyl,4β,14α-dimethyl-9β,19-cyclo-5α-ergost-24(241)-en-3β-ol",singleR,9,19). bond("4α-formyl,4β,14α-dimethyl-9β,19-cyclo-5α-ergost-24(241)-en-3β-ol",singleR,10,19).
+bond("4α-formyl,4β,14α-dimethyl-9β,19-cyclo-5α-ergost-24(241)-en-3β-ol",single,11,12). bond("4α-formyl,4β,14α-dimethyl-9β,19-cyclo-5α-ergost-24(241)-en-3β-ol",single,12,13). bond("4α-formyl,4β,14α-dimethyl-9β,19-cyclo-5α-ergost-24(241)-en-3β-ol",single,13,14).
+bond("4α-formyl,4β,14α-dimethyl-9β,19-cyclo-5α-ergost-24(241)-en-3β-ol",single,14,15). bond("4α-formyl,4β,14α-dimethyl-9β,19-cyclo-5α-ergost-24(241)-en-3β-ol",singleS,14,30). bond("4α-formyl,4β,14α-dimethyl-9β,19-cyclo-5α-ergost-24(241)-en-3β-ol",single,15,16).
+bond("4α-formyl,4β,14α-dimethyl-9β,19-cyclo-5α-ergost-24(241)-en-3β-ol",single,16,17). bond("4α-formyl,4β,14α-dimethyl-9β,19-cyclo-5α-ergost-24(241)-en-3β-ol",single,13,17). bond("4α-formyl,4β,14α-dimethyl-9β,19-cyclo-5α-ergost-24(241)-en-3β-ol",singleR,13,18).
+bond("4α-formyl,4β,14α-dimethyl-9β,19-cyclo-5α-ergost-24(241)-en-3β-ol",singleR,17,20). bond("4α-formyl,4β,14α-dimethyl-9β,19-cyclo-5α-ergost-24(241)-en-3β-ol",singleS,20,21). bond("4α-formyl,4β,14α-dimethyl-9β,19-cyclo-5α-ergost-24(241)-en-3β-ol",single,20,22).
+bond("4α-formyl,4β,14α-dimethyl-9β,19-cyclo-5α-ergost-24(241)-en-3β-ol",single,22,23). bond("4α-formyl,4β,14α-dimethyl-9β,19-cyclo-5α-ergost-24(241)-en-3β-ol",single,23,24). bond("4α-formyl,4β,14α-dimethyl-9β,19-cyclo-5α-ergost-24(241)-en-3β-ol",double,24,241).
+bond("4α-formyl,4β,14α-dimethyl-9β,19-cyclo-5α-ergost-24(241)-en-3β-ol",single,24,25). bond("4α-formyl,4β,14α-dimethyl-9β,19-cyclo-5α-ergost-24(241)-en-3β-ol",single,25,26). bond("4α-formyl,4β,14α-dimethyl-9β,19-cyclo-5α-ergost-24(241)-en-3β-ol",single,25,27).
+bond("4α-formyl,4β,14α-dimethyl-9β,19-cyclo-5α-ergost-24(241)-en-3β-ol",double,28,32).
+
+atom("4α-carboxy-4β,14α-dimethyl-9β,19-cyclo-5α-ergost-24(241)-en-3β-ol",1..24,carb). atom("4α-carboxy-4β,14α-dimethyl-9β,19-cyclo-5α-ergost-24(241)-en-3β-ol",241,carb). atom("4α-carboxy-4β,14α-dimethyl-9β,19-cyclo-5α-ergost-24(241)-en-3β-ol",25..30,carb).
+atom("4α-carboxy-4β,14α-dimethyl-9β,19-cyclo-5α-ergost-24(241)-en-3β-ol",31,oxyg). atom("4α-carboxy-4β,14α-dimethyl-9β,19-cyclo-5α-ergost-24(241)-en-3β-ol",32..33,oxyg).
+bond("4α-carboxy-4β,14α-dimethyl-9β,19-cyclo-5α-ergost-24(241)-en-3β-ol",single,1,2). bond("4α-carboxy-4β,14α-dimethyl-9β,19-cyclo-5α-ergost-24(241)-en-3β-ol",single,1,10). bond("4α-carboxy-4β,14α-dimethyl-9β,19-cyclo-5α-ergost-24(241)-en-3β-ol",single,2,3).
+bond("4α-carboxy-4β,14α-dimethyl-9β,19-cyclo-5α-ergost-24(241)-en-3β-ol",single,3,4). bond("4α-carboxy-4β,14α-dimethyl-9β,19-cyclo-5α-ergost-24(241)-en-3β-ol",singleR,3,31). bond("4α-carboxy-4β,14α-dimethyl-9β,19-cyclo-5α-ergost-24(241)-en-3β-ol",single,4,5).
+bond("4α-carboxy-4β,14α-dimethyl-9β,19-cyclo-5α-ergost-24(241)-en-3β-ol",singleR,4,29). bond("4α-carboxy-4β,14α-dimethyl-9β,19-cyclo-5α-ergost-24(241)-en-3β-ol",singleS,4,28). bond("4α-carboxy-4β,14α-dimethyl-9β,19-cyclo-5α-ergost-24(241)-en-3β-ol",single,5,6).
+bond("4α-carboxy-4β,14α-dimethyl-9β,19-cyclo-5α-ergost-24(241)-en-3β-ol",single,5,10). bond("4α-carboxy-4β,14α-dimethyl-9β,19-cyclo-5α-ergost-24(241)-en-3β-ol",single,6,7). bond("4α-carboxy-4β,14α-dimethyl-9β,19-cyclo-5α-ergost-24(241)-en-3β-ol",single,7,8).
+bond("4α-carboxy-4β,14α-dimethyl-9β,19-cyclo-5α-ergost-24(241)-en-3β-ol",single,8,9). bond("4α-carboxy-4β,14α-dimethyl-9β,19-cyclo-5α-ergost-24(241)-en-3β-ol",single,8,14). bond("4α-carboxy-4β,14α-dimethyl-9β,19-cyclo-5α-ergost-24(241)-en-3β-ol",single,9,10).
+bond("4α-carboxy-4β,14α-dimethyl-9β,19-cyclo-5α-ergost-24(241)-en-3β-ol",single,9,11).bond("4α-carboxy-4β,14α-dimethyl-9β,19-cyclo-5α-ergost-24(241)-en-3β-ol",singleR,9,19). bond("4α-carboxy-4β,14α-dimethyl-9β,19-cyclo-5α-ergost-24(241)-en-3β-ol",singleR,10,19).
+bond("4α-carboxy-4β,14α-dimethyl-9β,19-cyclo-5α-ergost-24(241)-en-3β-ol",single,11,12). bond("4α-carboxy-4β,14α-dimethyl-9β,19-cyclo-5α-ergost-24(241)-en-3β-ol",single,12,13). bond("4α-carboxy-4β,14α-dimethyl-9β,19-cyclo-5α-ergost-24(241)-en-3β-ol",single,13,14).
+bond("4α-carboxy-4β,14α-dimethyl-9β,19-cyclo-5α-ergost-24(241)-en-3β-ol",single,14,15). bond("4α-carboxy-4β,14α-dimethyl-9β,19-cyclo-5α-ergost-24(241)-en-3β-ol",singleS,14,30). bond("4α-carboxy-4β,14α-dimethyl-9β,19-cyclo-5α-ergost-24(241)-en-3β-ol",single,15,16).
+bond("4α-carboxy-4β,14α-dimethyl-9β,19-cyclo-5α-ergost-24(241)-en-3β-ol",single,16,17). bond("4α-carboxy-4β,14α-dimethyl-9β,19-cyclo-5α-ergost-24(241)-en-3β-ol",single,13,17). bond("4α-carboxy-4β,14α-dimethyl-9β,19-cyclo-5α-ergost-24(241)-en-3β-ol",singleR,13,18).
+bond("4α-carboxy-4β,14α-dimethyl-9β,19-cyclo-5α-ergost-24(241)-en-3β-ol",singleR,17,20). bond("4α-carboxy-4β,14α-dimethyl-9β,19-cyclo-5α-ergost-24(241)-en-3β-ol",singleS,20,21). bond("4α-carboxy-4β,14α-dimethyl-9β,19-cyclo-5α-ergost-24(241)-en-3β-ol",single,20,22).
+bond("4α-carboxy-4β,14α-dimethyl-9β,19-cyclo-5α-ergost-24(241)-en-3β-ol",single,22,23). bond("4α-carboxy-4β,14α-dimethyl-9β,19-cyclo-5α-ergost-24(241)-en-3β-ol",single,23,24). bond("4α-carboxy-4β,14α-dimethyl-9β,19-cyclo-5α-ergost-24(241)-en-3β-ol",double,24,241).
+bond("4α-carboxy-4β,14α-dimethyl-9β,19-cyclo-5α-ergost-24(241)-en-3β-ol",single,24,25). bond("4α-carboxy-4β,14α-dimethyl-9β,19-cyclo-5α-ergost-24(241)-en-3β-ol",single,25,26). bond("4α-carboxy-4β,14α-dimethyl-9β,19-cyclo-5α-ergost-24(241)-en-3β-ol",single,25,27).
+bond("4α-carboxy-4β,14α-dimethyl-9β,19-cyclo-5α-ergost-24(241)-en-3β-ol",double,28,32). bond("4α-carboxy-4β,14α-dimethyl-9β,19-cyclo-5α-ergost-24(241)-en-3β-ol",single,28,33).
+
+atom("cycloeucalenone",1..24,carb). atom("cycloeucalenone",241,carb). atom("cycloeucalenone",25..28,carb).
+atom("cycloeucalenone",30,carb). atom("cycloeucalenone",31,oxyg).
+bond("cycloeucalenone",single,1,2). bond("cycloeucalenone",single,1,10). bond("cycloeucalenone",single,2,3).
+bond("cycloeucalenone",single,3,4). bond("cycloeucalenone",double,3,31). bond("cycloeucalenone",single,4,5).
+bond("cycloeucalenone",singleS,4,28). bond("cycloeucalenone",single,5,6). bond("cycloeucalenone",single,5,10).
+bond("cycloeucalenone",single,6,7). bond("cycloeucalenone",single,7,8). bond("cycloeucalenone",single,8,9).
+bond("cycloeucalenone",single,8,14). bond("cycloeucalenone",single,9,10). bond("cycloeucalenone",single,9,11).
+bond("cycloeucalenone",singleR,9,19). bond("cycloeucalenone",singleR,10,19). bond("cycloeucalenone",single,11,12).
+bond("cycloeucalenone",single,12,13). bond("cycloeucalenone",single,13,14). bond("cycloeucalenone",single,14,15).
+bond("cycloeucalenone",singleS,14,30). bond("cycloeucalenone",single,15,16). bond("cycloeucalenone",single,16,17).
+bond("cycloeucalenone",single,13,17). bond("cycloeucalenone",singleR,13,18). bond("cycloeucalenone",singleR,17,20).
+bond("cycloeucalenone",singleS,20,21). bond("cycloeucalenone",single,20,22). bond("cycloeucalenone",single,22,23).
+bond("cycloeucalenone",single,23,24). bond("cycloeucalenone",double,24,241). bond("cycloeucalenone",single,24,25).
+bond("cycloeucalenone",single,25,26). bond("cycloeucalenone",single,25,27).
+
+atom("cycloeucalenol",1..24,carb). atom("cycloeucalenol",241,carb). atom("cycloeucalenol",25..28,carb).
+atom("cycloeucalenol",30,carb). atom("cycloeucalenol",31,oxyg).
+bond("cycloeucalenol",single,1,2). bond("cycloeucalenol",single,1,10). bond("cycloeucalenol",single,2,3).
+bond("cycloeucalenol",single,3,4). bond("cycloeucalenol",singleR,3,31). bond("cycloeucalenol",single,4,5).
+bond("cycloeucalenol",singleS,4,28). bond("cycloeucalenol",single,5,6). bond("cycloeucalenol",single,5,10).
+bond("cycloeucalenol",single,6,7). bond("cycloeucalenol",single,7,8). bond("cycloeucalenol",single,8,9).
+bond("cycloeucalenol",single,8,14). bond("cycloeucalenol",single,9,10). bond("cycloeucalenol",single,9,11).
+bond("cycloeucalenol",singleR,9,19). bond("cycloeucalenol",singleR,10,19). bond("cycloeucalenol",single,11,12).
+bond("cycloeucalenol",single,12,13). bond("cycloeucalenol",single,13,14). bond("cycloeucalenol",single,14,15).
+bond("cycloeucalenol",singleS,14,30). bond("cycloeucalenol",single,15,16). bond("cycloeucalenol",single,16,17).
+bond("cycloeucalenol",single,13,17). bond("cycloeucalenol",singleR,13,18). bond("cycloeucalenol",singleR,17,20).
+bond("cycloeucalenol",singleS,20,21). bond("cycloeucalenol",single,20,22). bond("cycloeucalenol",single,22,23).
+bond("cycloeucalenol",single,23,24). bond("cycloeucalenol",double,24,241). bond("cycloeucalenol",single,24,25).
+bond("cycloeucalenol",single,25,26). bond("cycloeucalenol",single,25,27).
+
+atom("obtusifoliol",1..24,carb). atom("obtusifoliol",241,carb). atom("obtusifoliol",25..28,carb).
+atom("obtusifoliol",30,carb). atom("obtusifoliol",31,oxyg).
+bond("obtusifoliol",single,1,2). bond("obtusifoliol",single,1,10). bond("obtusifoliol",single,2,3).
+bond("obtusifoliol",single,3,4). bond("obtusifoliol",singleR,3,31). bond("obtusifoliol",single,4,5).
+bond("obtusifoliol",singleS,4,28). bond("obtusifoliol",single,5,6). bond("obtusifoliol",single,5,10).
+bond("obtusifoliol",single,6,7). bond("obtusifoliol",single,7,8). bond("obtusifoliol",double,8,9).
+bond("obtusifoliol",single,8,14). bond("obtusifoliol",single,9,10). bond("obtusifoliol",single,9,11).
+bond("obtusifoliol",singleR,10,19). bond("obtusifoliol",single,11,12). bond("obtusifoliol",single,12,13).
+bond("obtusifoliol",single,13,14). bond("obtusifoliol",single,14,15). bond("obtusifoliol",singleS,14,30).
+bond("obtusifoliol",single,15,16). bond("obtusifoliol",single,16,17). bond("obtusifoliol",single,13,17).
+bond("obtusifoliol",singleR,13,18). bond("obtusifoliol",singleR,17,20). bond("obtusifoliol",singleS,20,21).
+bond("obtusifoliol",single,20,22). bond("obtusifoliol",single,22,23). bond("obtusifoliol",single,23,24).
+bond("obtusifoliol",double,24,241). bond("obtusifoliol",single,24,25). bond("obtusifoliol",single,25,26).
+bond("obtusifoliol",single,25,27).
+
+atom("4α-methyl-5α-ergosta-8,14,24(28)-trien-3β-ol",1..24,carb). atom("4α-methyl-5α-ergosta-8,14,24(28)-trien-3β-ol",241,carb). atom("4α-methyl-5α-ergosta-8,14,24(28)-trien-3β-ol",25..28,carb).
+atom("4α-methyl-5α-ergosta-8,14,24(28)-trien-3β-ol",31,oxyg).
+bond("4α-methyl-5α-ergosta-8,14,24(28)-trien-3β-ol",single,1,2). bond("4α-methyl-5α-ergosta-8,14,24(28)-trien-3β-ol",single,1,10). bond("4α-methyl-5α-ergosta-8,14,24(28)-trien-3β-ol",single,2,3).
+bond("4α-methyl-5α-ergosta-8,14,24(28)-trien-3β-ol",single,3,4). bond("4α-methyl-5α-ergosta-8,14,24(28)-trien-3β-ol",singleR,3,31). bond("4α-methyl-5α-ergosta-8,14,24(28)-trien-3β-ol",single,4,5).
+bond("4α-methyl-5α-ergosta-8,14,24(28)-trien-3β-ol",singleS,4,28). bond("4α-methyl-5α-ergosta-8,14,24(28)-trien-3β-ol",single,5,6). bond("4α-methyl-5α-ergosta-8,14,24(28)-trien-3β-ol",single,5,10).
+bond("4α-methyl-5α-ergosta-8,14,24(28)-trien-3β-ol",single,6,7). bond("4α-methyl-5α-ergosta-8,14,24(28)-trien-3β-ol",single,7,8). bond("4α-methyl-5α-ergosta-8,14,24(28)-trien-3β-ol",double,8,9).
+bond("4α-methyl-5α-ergosta-8,14,24(28)-trien-3β-ol",single,8,14). bond("4α-methyl-5α-ergosta-8,14,24(28)-trien-3β-ol",single,9,10). bond("4α-methyl-5α-ergosta-8,14,24(28)-trien-3β-ol",single,9,11).
+bond("4α-methyl-5α-ergosta-8,14,24(28)-trien-3β-ol",singleR,10,19). bond("4α-methyl-5α-ergosta-8,14,24(28)-trien-3β-ol",single,11,12). bond("4α-methyl-5α-ergosta-8,14,24(28)-trien-3β-ol",single,12,13).
+bond("4α-methyl-5α-ergosta-8,14,24(28)-trien-3β-ol",single,13,14). bond("4α-methyl-5α-ergosta-8,14,24(28)-trien-3β-ol",double,14,15). bond("4α-methyl-5α-ergosta-8,14,24(28)-trien-3β-ol",single,15,16).
+bond("4α-methyl-5α-ergosta-8,14,24(28)-trien-3β-ol",single,16,17). bond("4α-methyl-5α-ergosta-8,14,24(28)-trien-3β-ol",single,13,17). bond("4α-methyl-5α-ergosta-8,14,24(28)-trien-3β-ol",singleR,13,18).
+bond("4α-methyl-5α-ergosta-8,14,24(28)-trien-3β-ol",singleR,17,20). bond("4α-methyl-5α-ergosta-8,14,24(28)-trien-3β-ol",singleS,20,21). bond("4α-methyl-5α-ergosta-8,14,24(28)-trien-3β-ol",single,20,22).
+bond("4α-methyl-5α-ergosta-8,14,24(28)-trien-3β-ol",single,22,23). bond("4α-methyl-5α-ergosta-8,14,24(28)-trien-3β-ol",single,23,24). bond("4α-methyl-5α-ergosta-8,14,24(28)-trien-3β-ol",double,24,241).
+bond("4α-methyl-5α-ergosta-8,14,24(28)-trien-3β-ol",single,24,25). bond("4α-methyl-5α-ergosta-8,14,24(28)-trien-3β-ol",single,25,26). bond("4α-methyl-5α-ergosta-8,14,24(28)-trien-3β-ol",single,25,27).
+
+atom("4α-methyl-5α-ergosta-8,24-dien-3β-ol",1..24,carb). atom("4α-methyl-5α-ergosta-8,24-dien-3β-ol",241,carb). atom("4α-methyl-5α-ergosta-8,24-dien-3β-ol",25..28,carb).
+atom("4α-methyl-5α-ergosta-8,24-dien-3β-ol",31,oxyg).
+bond("4α-methyl-5α-ergosta-8,24-dien-3β-ol",single,1,2). bond("4α-methyl-5α-ergosta-8,24-dien-3β-ol",single,1,10). bond("4α-methyl-5α-ergosta-8,24-dien-3β-ol",single,2,3).
+bond("4α-methyl-5α-ergosta-8,24-dien-3β-ol",single,3,4). bond("4α-methyl-5α-ergosta-8,24-dien-3β-ol",singleR,3,31). bond("4α-methyl-5α-ergosta-8,24-dien-3β-ol",single,4,5).
+bond("4α-methyl-5α-ergosta-8,24-dien-3β-ol",singleS,4,28). bond("4α-methyl-5α-ergosta-8,24-dien-3β-ol",single,5,6). bond("4α-methyl-5α-ergosta-8,24-dien-3β-ol",single,5,10).
+bond("4α-methyl-5α-ergosta-8,24-dien-3β-ol",single,6,7). bond("4α-methyl-5α-ergosta-8,24-dien-3β-ol",single,7,8). bond("4α-methyl-5α-ergosta-8,24-dien-3β-ol",double,8,9).
+bond("4α-methyl-5α-ergosta-8,24-dien-3β-ol",single,8,14). bond("4α-methyl-5α-ergosta-8,24-dien-3β-ol",single,9,10). bond("4α-methyl-5α-ergosta-8,24-dien-3β-ol",single,9,11).
+bond("4α-methyl-5α-ergosta-8,24-dien-3β-ol",singleR,10,19). bond("4α-methyl-5α-ergosta-8,24-dien-3β-ol",single,11,12). bond("4α-methyl-5α-ergosta-8,24-dien-3β-ol",single,12,13).
+bond("4α-methyl-5α-ergosta-8,24-dien-3β-ol",single,13,14). bond("4α-methyl-5α-ergosta-8,24-dien-3β-ol",single,14,15). bond("4α-methyl-5α-ergosta-8,24-dien-3β-ol",single,15,16).
+bond("4α-methyl-5α-ergosta-8,24-dien-3β-ol",single,16,17). bond("4α-methyl-5α-ergosta-8,24-dien-3β-ol",single,13,17). bond("4α-methyl-5α-ergosta-8,24-dien-3β-ol",singleR,13,18).
+bond("4α-methyl-5α-ergosta-8,24-dien-3β-ol",singleR,17,20). bond("4α-methyl-5α-ergosta-8,24-dien-3β-ol",singleS,20,21). bond("4α-methyl-5α-ergosta-8,24-dien-3β-ol",single,20,22).
+bond("4α-methyl-5α-ergosta-8,24-dien-3β-ol",single,22,23). bond("4α-methyl-5α-ergosta-8,24-dien-3β-ol",single,23,24). bond("4α-methyl-5α-ergosta-8,24-dien-3β-ol",double,24,241).
+bond("4α-methyl-5α-ergosta-8,24-dien-3β-ol",single,24,25). bond("4α-methyl-5α-ergosta-8,24-dien-3β-ol",single,25,26). bond("4α-methyl-5α-ergosta-8,24-dien-3β-ol",single,25,27).
+
+atom("24-methylenelophenol",1..24,carb). atom("24-methylenelophenol",241,carb). atom("24-methylenelophenol",25..28,carb).
+atom("24-methylenelophenol",31,oxyg).
+bond("24-methylenelophenol",single,1,2). bond("24-methylenelophenol",single,1,10). bond("24-methylenelophenol",single,2,3).
+bond("24-methylenelophenol",single,3,4). bond("24-methylenelophenol",singleR,3,31). bond("24-methylenelophenol",single,4,5).
+bond("24-methylenelophenol",singleS,4,28). bond("24-methylenelophenol",single,5,6). bond("24-methylenelophenol",single,5,10).
+bond("24-methylenelophenol",single,6,7). bond("24-methylenelophenol",double,7,8). bond("24-methylenelophenol",single,8,9).
+bond("24-methylenelophenol",single,8,14). bond("24-methylenelophenol",single,9,10). bond("24-methylenelophenol",single,9,11).
+bond("24-methylenelophenol",singleR,10,19). bond("24-methylenelophenol",single,11,12). bond("24-methylenelophenol",single,12,13).
+bond("24-methylenelophenol",single,13,14). bond("24-methylenelophenol",single,14,15). bond("24-methylenelophenol",single,15,16).
+bond("24-methylenelophenol",single,16,17). bond("24-methylenelophenol",single,13,17). bond("24-methylenelophenol",singleR,13,18).
+bond("24-methylenelophenol",singleR,17,20). bond("24-methylenelophenol",singleS,20,21). bond("24-methylenelophenol",single,20,22).
+bond("24-methylenelophenol",single,22,23). bond("24-methylenelophenol",single,23,24). bond("24-methylenelophenol",double,24,241).
+bond("24-methylenelophenol",single,24,25). bond("24-methylenelophenol",single,25,26). bond("24-methylenelophenol",single,25,27).
+
+% 24-ethylidenelophenol branch
+
+atom("24-ethylidenelophenol",1..24,carb). atom("24-ethylidenelophenol",241,carb). atom("24-ethylidenelophenol",242,carb).
+atom("24-ethylidenelophenol",25..28,carb). atom("24-ethylidenelophenol",31,oxyg).
+bond("24-ethylidenelophenol",single,1,2). bond("24-ethylidenelophenol",single,1,10). bond("24-ethylidenelophenol",single,2,3).
+bond("24-ethylidenelophenol",single,3,4). bond("24-ethylidenelophenol",singleR,3,31). bond("24-ethylidenelophenol",single,4,5).
+bond("24-ethylidenelophenol",singleS,4,28). bond("24-ethylidenelophenol",single,5,6). bond("24-ethylidenelophenol",single,5,10).
+bond("24-ethylidenelophenol",single,6,7). bond("24-ethylidenelophenol",double,7,8). bond("24-ethylidenelophenol",single,8,9).
+bond("24-ethylidenelophenol",single,8,14). bond("24-ethylidenelophenol",single,9,10). bond("24-ethylidenelophenol",single,9,11).
+bond("24-ethylidenelophenol",singleR,10,19). bond("24-ethylidenelophenol",single,11,12). bond("24-ethylidenelophenol",single,12,13).
+bond("24-ethylidenelophenol",single,13,14). bond("24-ethylidenelophenol",single,14,15). bond("24-ethylidenelophenol",single,15,16).
+bond("24-ethylidenelophenol",single,16,17). bond("24-ethylidenelophenol",single,13,17). bond("24-ethylidenelophenol",singleR,13,18).
+bond("24-ethylidenelophenol",singleR,17,20). bond("24-ethylidenelophenol",singleS,20,21). bond("24-ethylidenelophenol",single,20,22).
+bond("24-ethylidenelophenol",single,22,23). bond("24-ethylidenelophenol",single,23,24). bond("24-ethylidenelophenol",double,24,241).
+bond("24-ethylidenelophenol",single,241,242). bond("24-ethylidenelophenol",single,24,25). bond("24-ethylidenelophenol",single,25,26).
+bond("24-ethylidenelophenol",single,25,27).
+
+atom("4α-hydroxymethyl-stigmasta-7,24(241)-dien-3β-ol",1..24,carb). atom("4α-hydroxymethyl-stigmasta-7,24(241)-dien-3β-ol",241,carb). atom("4α-hydroxymethyl-stigmasta-7,24(241)-dien-3β-ol",242,carb).
+atom("4α-hydroxymethyl-stigmasta-7,24(241)-dien-3β-ol",25..28,carb). atom("4α-hydroxymethyl-stigmasta-7,24(241)-dien-3β-ol",31..32,oxyg).
+bond("4α-hydroxymethyl-stigmasta-7,24(241)-dien-3β-ol",single,1,2). bond("4α-hydroxymethyl-stigmasta-7,24(241)-dien-3β-ol",single,1,10). bond("4α-hydroxymethyl-stigmasta-7,24(241)-dien-3β-ol",single,2,3).
+bond("4α-hydroxymethyl-stigmasta-7,24(241)-dien-3β-ol",single,3,4). bond("4α-hydroxymethyl-stigmasta-7,24(241)-dien-3β-ol",singleR,3,31). bond("4α-hydroxymethyl-stigmasta-7,24(241)-dien-3β-ol",single,4,5).
+bond("4α-hydroxymethyl-stigmasta-7,24(241)-dien-3β-ol",singleS,4,28). bond("4α-hydroxymethyl-stigmasta-7,24(241)-dien-3β-ol",single,5,6). bond("4α-hydroxymethyl-stigmasta-7,24(241)-dien-3β-ol",single,5,10).
+bond("4α-hydroxymethyl-stigmasta-7,24(241)-dien-3β-ol",single,6,7). bond("4α-hydroxymethyl-stigmasta-7,24(241)-dien-3β-ol",double,7,8). bond("4α-hydroxymethyl-stigmasta-7,24(241)-dien-3β-ol",single,8,9).
+bond("4α-hydroxymethyl-stigmasta-7,24(241)-dien-3β-ol",single,8,14). bond("4α-hydroxymethyl-stigmasta-7,24(241)-dien-3β-ol",single,9,10). bond("4α-hydroxymethyl-stigmasta-7,24(241)-dien-3β-ol",single,9,11).
+bond("4α-hydroxymethyl-stigmasta-7,24(241)-dien-3β-ol",singleR,10,19). bond("4α-hydroxymethyl-stigmasta-7,24(241)-dien-3β-ol",single,11,12). bond("4α-hydroxymethyl-stigmasta-7,24(241)-dien-3β-ol",single,12,13).
+bond("4α-hydroxymethyl-stigmasta-7,24(241)-dien-3β-ol",single,13,14). bond("4α-hydroxymethyl-stigmasta-7,24(241)-dien-3β-ol",single,14,15). bond("4α-hydroxymethyl-stigmasta-7,24(241)-dien-3β-ol",single,15,16).
+bond("4α-hydroxymethyl-stigmasta-7,24(241)-dien-3β-ol",single,16,17). bond("4α-hydroxymethyl-stigmasta-7,24(241)-dien-3β-ol",single,13,17). bond("4α-hydroxymethyl-stigmasta-7,24(241)-dien-3β-ol",singleR,13,18).
+bond("4α-hydroxymethyl-stigmasta-7,24(241)-dien-3β-ol",singleR,17,20). bond("4α-hydroxymethyl-stigmasta-7,24(241)-dien-3β-ol",singleS,20,21). bond("4α-hydroxymethyl-stigmasta-7,24(241)-dien-3β-ol",single,20,22).
+bond("4α-hydroxymethyl-stigmasta-7,24(241)-dien-3β-ol",single,22,23). bond("4α-hydroxymethyl-stigmasta-7,24(241)-dien-3β-ol",single,23,24). bond("4α-hydroxymethyl-stigmasta-7,24(241)-dien-3β-ol",double,24,241).
+bond("4α-hydroxymethyl-stigmasta-7,24(241)-dien-3β-ol",single,241,242). bond("4α-hydroxymethyl-stigmasta-7,24(241)-dien-3β-ol",single,24,25). bond("4α-hydroxymethyl-stigmasta-7,24(241)-dien-3β-ol",single,25,26).
+bond("4α-hydroxymethyl-stigmasta-7,24(241)-dien-3β-ol",single,25,27). bond("4α-hydroxymethyl-stigmasta-7,24(241)-dien-3β-ol",single,28,32).
+
+atom("4α-formyl-stigmasta-7,24(241)-dien-3β-ol",1..24,carb). atom("4α-formyl-stigmasta-7,24(241)-dien-3β-ol",241,carb). atom("4α-formyl-stigmasta-7,24(241)-dien-3β-ol",242,carb).
+atom("4α-formyl-stigmasta-7,24(241)-dien-3β-ol",25..28,carb). atom("4α-formyl-stigmasta-7,24(241)-dien-3β-ol",31..32,oxyg).
+bond("4α-formyl-stigmasta-7,24(241)-dien-3β-ol",single,1,2). bond("4α-formyl-stigmasta-7,24(241)-dien-3β-ol",single,1,10). bond("4α-formyl-stigmasta-7,24(241)-dien-3β-ol",single,2,3).
+bond("4α-formyl-stigmasta-7,24(241)-dien-3β-ol",single,3,4). bond("4α-formyl-stigmasta-7,24(241)-dien-3β-ol",singleR,3,31). bond("4α-formyl-stigmasta-7,24(241)-dien-3β-ol",single,4,5).
+bond("4α-formyl-stigmasta-7,24(241)-dien-3β-ol",singleS,4,28). bond("4α-formyl-stigmasta-7,24(241)-dien-3β-ol",single,5,6). bond("4α-formyl-stigmasta-7,24(241)-dien-3β-ol",single,5,10).
+bond("4α-formyl-stigmasta-7,24(241)-dien-3β-ol",single,6,7). bond("4α-formyl-stigmasta-7,24(241)-dien-3β-ol",double,7,8). bond("4α-formyl-stigmasta-7,24(241)-dien-3β-ol",single,8,9).
+bond("4α-formyl-stigmasta-7,24(241)-dien-3β-ol",single,8,14). bond("4α-formyl-stigmasta-7,24(241)-dien-3β-ol",single,9,10). bond("4α-formyl-stigmasta-7,24(241)-dien-3β-ol",single,9,11).
+bond("4α-formyl-stigmasta-7,24(241)-dien-3β-ol",singleR,10,19). bond("4α-formyl-stigmasta-7,24(241)-dien-3β-ol",single,11,12). bond("4α-formyl-stigmasta-7,24(241)-dien-3β-ol",single,12,13).
+bond("4α-formyl-stigmasta-7,24(241)-dien-3β-ol",single,13,14). bond("4α-formyl-stigmasta-7,24(241)-dien-3β-ol",single,14,15). bond("4α-formyl-stigmasta-7,24(241)-dien-3β-ol",single,15,16).
+bond("4α-formyl-stigmasta-7,24(241)-dien-3β-ol",single,16,17). bond("4α-formyl-stigmasta-7,24(241)-dien-3β-ol",single,13,17). bond("4α-formyl-stigmasta-7,24(241)-dien-3β-ol",singleR,13,18).
+bond("4α-formyl-stigmasta-7,24(241)-dien-3β-ol",singleR,17,20). bond("4α-formyl-stigmasta-7,24(241)-dien-3β-ol",singleS,20,21). bond("4α-formyl-stigmasta-7,24(241)-dien-3β-ol",single,20,22).
+bond("4α-formyl-stigmasta-7,24(241)-dien-3β-ol",single,22,23). bond("4α-formyl-stigmasta-7,24(241)-dien-3β-ol",single,23,24). bond("4α-formyl-stigmasta-7,24(241)-dien-3β-ol",double,24,241).
+bond("4α-formyl-stigmasta-7,24(241)-dien-3β-ol",single,241,242). bond("4α-formyl-stigmasta-7,24(241)-dien-3β-ol",single,24,25). bond("4α-formyl-stigmasta-7,24(241)-dien-3β-ol",single,25,26).
+bond("4α-formyl-stigmasta-7,24(241)-dien-3β-ol",single,25,27). bond("4α-formyl-stigmasta-7,24(241)-dien-3β-ol",double,28,32).
+
+atom("4α-carboxy-stigmasta-7,24(241)-dien-3β-ol",1..24,carb). atom("4α-carboxy-stigmasta-7,24(241)-dien-3β-ol",241,carb). atom("4α-carboxy-stigmasta-7,24(241)-dien-3β-ol",242,carb).
+atom("4α-carboxy-stigmasta-7,24(241)-dien-3β-ol",25..28,carb). atom("4α-carboxy-stigmasta-7,24(241)-dien-3β-ol",31..33,oxyg).
+bond("4α-carboxy-stigmasta-7,24(241)-dien-3β-ol",single,1,2). bond("4α-carboxy-stigmasta-7,24(241)-dien-3β-ol",single,1,10). bond("4α-carboxy-stigmasta-7,24(241)-dien-3β-ol",single,2,3).
+bond("4α-carboxy-stigmasta-7,24(241)-dien-3β-ol",single,3,4). bond("4α-carboxy-stigmasta-7,24(241)-dien-3β-ol",singleR,3,31). bond("4α-carboxy-stigmasta-7,24(241)-dien-3β-ol",single,4,5).
+bond("4α-carboxy-stigmasta-7,24(241)-dien-3β-ol",singleS,4,28). bond("4α-carboxy-stigmasta-7,24(241)-dien-3β-ol",single,5,6). bond("4α-carboxy-stigmasta-7,24(241)-dien-3β-ol",single,5,10).
+bond("4α-carboxy-stigmasta-7,24(241)-dien-3β-ol",single,6,7). bond("4α-carboxy-stigmasta-7,24(241)-dien-3β-ol",double,7,8). bond("4α-carboxy-stigmasta-7,24(241)-dien-3β-ol",single,8,9).
+bond("4α-carboxy-stigmasta-7,24(241)-dien-3β-ol",single,8,14). bond("4α-carboxy-stigmasta-7,24(241)-dien-3β-ol",single,9,10). bond("4α-carboxy-stigmasta-7,24(241)-dien-3β-ol",single,9,11).
+bond("4α-carboxy-stigmasta-7,24(241)-dien-3β-ol",singleR,10,19). bond("4α-carboxy-stigmasta-7,24(241)-dien-3β-ol",single,11,12). bond("4α-carboxy-stigmasta-7,24(241)-dien-3β-ol",single,12,13).
+bond("4α-carboxy-stigmasta-7,24(241)-dien-3β-ol",single,13,14). bond("4α-carboxy-stigmasta-7,24(241)-dien-3β-ol",single,14,15). bond("4α-carboxy-stigmasta-7,24(241)-dien-3β-ol",single,15,16).
+bond("4α-carboxy-stigmasta-7,24(241)-dien-3β-ol",single,16,17). bond("4α-carboxy-stigmasta-7,24(241)-dien-3β-ol",single,13,17). bond("4α-carboxy-stigmasta-7,24(241)-dien-3β-ol",singleR,13,18).
+bond("4α-carboxy-stigmasta-7,24(241)-dien-3β-ol",singleR,17,20). bond("4α-carboxy-stigmasta-7,24(241)-dien-3β-ol",singleS,20,21). bond("4α-carboxy-stigmasta-7,24(241)-dien-3β-ol",single,20,22).
+bond("4α-carboxy-stigmasta-7,24(241)-dien-3β-ol",single,22,23). bond("4α-carboxy-stigmasta-7,24(241)-dien-3β-ol",single,23,24). bond("4α-carboxy-stigmasta-7,24(241)-dien-3β-ol",double,24,241).
+bond("4α-carboxy-stigmasta-7,24(241)-dien-3β-ol",single,241,242). bond("4α-carboxy-stigmasta-7,24(241)-dien-3β-ol",single,24,25). bond("4α-carboxy-stigmasta-7,24(241)-dien-3β-ol",single,25,26).
+bond("4α-carboxy-stigmasta-7,24(241)-dien-3β-ol",single,25,27). bond("4α-carboxy-stigmasta-7,24(241)-dien-3β-ol",double,28,32). bond("4α-carboxy-stigmasta-7,24(241)-dien-3β-ol",single,28,33).
+
+atom("avenastenone",1..24,carb). atom("avenastenone",241,carb). atom("avenastenone",242,carb).
+atom("avenastenone",25..27,carb). atom("avenastenone",31,oxyg).
+bond("avenastenone",single,1,2). bond("avenastenone",single,1,10). bond("avenastenone",single,2,3).
+bond("avenastenone",single,3,4). bond("avenastenone",double,3,31). bond("avenastenone",single,4,5).
+bond("avenastenone",single,5,6). bond("avenastenone",single,5,10). bond("avenastenone",single,6,7).
+bond("avenastenone",double,7,8). bond("avenastenone",single,8,9). bond("avenastenone",single,8,14).
+bond("avenastenone",single,9,10). bond("avenastenone",single,9,11). bond("avenastenone",singleR,10,19).
+bond("avenastenone",single,11,12). bond("avenastenone",single,12,13). bond("avenastenone",single,13,14).
+bond("avenastenone",single,14,15). bond("avenastenone",single,15,16). bond("avenastenone",single,16,17).
+bond("avenastenone",single,13,17). bond("avenastenone",singleR,13,18). bond("avenastenone",singleR,17,20).
+bond("avenastenone",singleS,20,21). bond("avenastenone",single,20,22). bond("avenastenone",single,22,23).
+bond("avenastenone",single,23,24). bond("avenastenone",double,24,241). bond("avenastenone",single,241,242).
+bond("avenastenone",single,24,25). bond("avenastenone",single,25,26). bond("avenastenone",single,25,27).
+
+atom("avenasterol",1..24,carb). atom("avenasterol",241,carb). atom("avenasterol",242,carb).
+atom("avenasterol",25..27,carb). atom("avenasterol",31,oxyg).
+bond("avenasterol",single,1,2). bond("avenasterol",single,1,10). bond("avenasterol",single,2,3).
+bond("avenasterol",single,3,4). bond("avenasterol",singleR,3,31). bond("avenasterol",single,4,5).
+bond("avenasterol",single,5,6). bond("avenasterol",single,5,10). bond("avenasterol",single,6,7).
+bond("avenasterol",double,7,8). bond("avenasterol",single,8,9). bond("avenasterol",single,8,14).
+bond("avenasterol",single,9,10). bond("avenasterol",single,9,11). bond("avenasterol",singleR,10,19).
+bond("avenasterol",single,11,12). bond("avenasterol",single,12,13). bond("avenasterol",single,13,14).
+bond("avenasterol",single,14,15). bond("avenasterol",single,15,16). bond("avenasterol",single,16,17).
+bond("avenasterol",single,13,17). bond("avenasterol",singleR,13,18). bond("avenasterol",singleR,17,20).
+bond("avenasterol",singleS,20,21). bond("avenasterol",single,20,22). bond("avenasterol",single,22,23).
+bond("avenasterol",single,23,24). bond("avenasterol",double,24,241). bond("avenasterol",single,241,242).
+bond("avenasterol",single,24,25). bond("avenasterol",single,25,26). bond("avenasterol",single,25,27).
+
+atom("5-dehydroavenasterol",1..24,carb). atom("5-dehydroavenasterol",241,carb). atom("5-dehydroavenasterol",242,carb).
+atom("5-dehydroavenasterol",25..27,carb). atom("5-dehydroavenasterol",31,oxyg).
+bond("5-dehydroavenasterol",single,1,2). bond("5-dehydroavenasterol",single,1,10). bond("5-dehydroavenasterol",single,2,3).
+bond("5-dehydroavenasterol",single,3,4). bond("5-dehydroavenasterol",singleR,3,31). bond("5-dehydroavenasterol",single,4,5).
+bond("5-dehydroavenasterol",double,5,6). bond("5-dehydroavenasterol",single,5,10). bond("5-dehydroavenasterol",single,6,7).
+bond("5-dehydroavenasterol",double,7,8). bond("5-dehydroavenasterol",single,8,9). bond("5-dehydroavenasterol",single,8,14).
+bond("5-dehydroavenasterol",single,9,10). bond("5-dehydroavenasterol",single,9,11). bond("5-dehydroavenasterol",singleR,10,19).
+bond("5-dehydroavenasterol",single,11,12). bond("5-dehydroavenasterol",single,12,13). bond("5-dehydroavenasterol",single,13,14).
+bond("5-dehydroavenasterol",single,14,15). bond("5-dehydroavenasterol",single,15,16). bond("5-dehydroavenasterol",single,16,17).
+bond("5-dehydroavenasterol",single,13,17). bond("5-dehydroavenasterol",singleR,13,18). bond("5-dehydroavenasterol",singleR,17,20).
+bond("5-dehydroavenasterol",singleS,20,21). bond("5-dehydroavenasterol",single,20,22). bond("5-dehydroavenasterol",single,22,23).
+bond("5-dehydroavenasterol",single,23,24). bond("5-dehydroavenasterol",double,24,241). bond("5-dehydroavenasterol",single,241,242).
+bond("5-dehydroavenasterol",single,24,25). bond("5-dehydroavenasterol",single,25,26). bond("5-dehydroavenasterol",single,25,27).
+
+atom("fucosterol",1..24,carb). atom("fucosterol",241,carb). atom("fucosterol",242,carb).
+atom("fucosterol",25..27,carb). atom("fucosterol",31,oxyg).
+bond("fucosterol",single,1,2). bond("fucosterol",single,1,10). bond("fucosterol",single,2,3).
+bond("fucosterol",single,3,4). bond("fucosterol",singleR,3,31). bond("fucosterol",single,4,5).
+bond("fucosterol",double,5,6). bond("fucosterol",single,5,10). bond("fucosterol",single,6,7).
+bond("fucosterol",single,7,8). bond("fucosterol",single,8,9). bond("fucosterol",single,8,14).
+bond("fucosterol",single,9,10). bond("fucosterol",single,9,11). bond("fucosterol",singleR,10,19).
+bond("fucosterol",single,11,12). bond("fucosterol",single,12,13). bond("fucosterol",single,13,14).
+bond("fucosterol",single,14,15). bond("fucosterol",single,15,16). bond("fucosterol",single,16,17).
+bond("fucosterol",single,13,17). bond("fucosterol",singleR,13,18). bond("fucosterol",singleR,17,20).
+bond("fucosterol",singleS,20,21). bond("fucosterol",single,20,22). bond("fucosterol",single,22,23).
+bond("fucosterol",single,23,24). bond("fucosterol",double,24,241). bond("fucosterol",single,241,242).
+bond("fucosterol",single,24,25). bond("fucosterol",single,25,26). bond("fucosterol",single,25,27).
+
+% episterol branch
+
+atom("4α-hydroxymethyl-ergosta-7,24(241)-dien-3β-ol",1..24,carb). atom("4α-hydroxymethyl-ergosta-7,24(241)-dien-3β-ol",241,carb). atom("4α-hydroxymethyl-ergosta-7,24(241)-dien-3β-ol",25..28,carb).
+atom("4α-hydroxymethyl-ergosta-7,24(241)-dien-3β-ol",31..32,oxyg).
+bond("4α-hydroxymethyl-ergosta-7,24(241)-dien-3β-ol",single,1,2). bond("4α-hydroxymethyl-ergosta-7,24(241)-dien-3β-ol",single,1,10). bond("4α-hydroxymethyl-ergosta-7,24(241)-dien-3β-ol",single,2,3).
+bond("4α-hydroxymethyl-ergosta-7,24(241)-dien-3β-ol",single,3,4). bond("4α-hydroxymethyl-ergosta-7,24(241)-dien-3β-ol",singleR,3,31). bond("4α-hydroxymethyl-ergosta-7,24(241)-dien-3β-ol",single,4,5).
+bond("4α-hydroxymethyl-ergosta-7,24(241)-dien-3β-ol",singleS,4,28). bond("4α-hydroxymethyl-ergosta-7,24(241)-dien-3β-ol",single,5,6). bond("4α-hydroxymethyl-ergosta-7,24(241)-dien-3β-ol",single,5,10).
+bond("4α-hydroxymethyl-ergosta-7,24(241)-dien-3β-ol",single,6,7). bond("4α-hydroxymethyl-ergosta-7,24(241)-dien-3β-ol",double,7,8). bond("4α-hydroxymethyl-ergosta-7,24(241)-dien-3β-ol",single,8,9).
+bond("4α-hydroxymethyl-ergosta-7,24(241)-dien-3β-ol",single,8,14). bond("4α-hydroxymethyl-ergosta-7,24(241)-dien-3β-ol",single,9,10). bond("4α-hydroxymethyl-ergosta-7,24(241)-dien-3β-ol",single,9,11).
+bond("4α-hydroxymethyl-ergosta-7,24(241)-dien-3β-ol",singleR,10,19). bond("4α-hydroxymethyl-ergosta-7,24(241)-dien-3β-ol",single,11,12). bond("4α-hydroxymethyl-ergosta-7,24(241)-dien-3β-ol",single,12,13).
+bond("4α-hydroxymethyl-ergosta-7,24(241)-dien-3β-ol",single,13,14). bond("4α-hydroxymethyl-ergosta-7,24(241)-dien-3β-ol",single,14,15). bond("4α-hydroxymethyl-ergosta-7,24(241)-dien-3β-ol",single,15,16).
+bond("4α-hydroxymethyl-ergosta-7,24(241)-dien-3β-ol",single,16,17). bond("4α-hydroxymethyl-ergosta-7,24(241)-dien-3β-ol",single,13,17). bond("4α-hydroxymethyl-ergosta-7,24(241)-dien-3β-ol",singleR,13,18).
+bond("4α-hydroxymethyl-ergosta-7,24(241)-dien-3β-ol",singleR,17,20). bond("4α-hydroxymethyl-ergosta-7,24(241)-dien-3β-ol",singleS,20,21). bond("4α-hydroxymethyl-ergosta-7,24(241)-dien-3β-ol",single,20,22).
+bond("4α-hydroxymethyl-ergosta-7,24(241)-dien-3β-ol",single,22,23). bond("4α-hydroxymethyl-ergosta-7,24(241)-dien-3β-ol",single,23,24). bond("4α-hydroxymethyl-ergosta-7,24(241)-dien-3β-ol",double,24,241).
+bond("4α-hydroxymethyl-ergosta-7,24(241)-dien-3β-ol",single,24,25). bond("4α-hydroxymethyl-ergosta-7,24(241)-dien-3β-ol",single,25,26). bond("4α-hydroxymethyl-ergosta-7,24(241)-dien-3β-ol",single,25,27).
+bond("4α-hydroxymethyl-ergosta-7,24(241)-dien-3β-ol",single,28,32).
+
+atom("4α-formyl-ergosta-7,24(241)-dien-3β-ol",1..24,carb). atom("4α-formyl-ergosta-7,24(241)-dien-3β-ol",241,carb). atom("4α-formyl-ergosta-7,24(241)-dien-3β-ol",25..28,carb).
+atom("4α-formyl-ergosta-7,24(241)-dien-3β-ol",31..32,oxyg).
+bond("4α-formyl-ergosta-7,24(241)-dien-3β-ol",single,1,2). bond("4α-formyl-ergosta-7,24(241)-dien-3β-ol",single,1,10). bond("4α-formyl-ergosta-7,24(241)-dien-3β-ol",single,2,3).
+bond("4α-formyl-ergosta-7,24(241)-dien-3β-ol",single,3,4). bond("4α-formyl-ergosta-7,24(241)-dien-3β-ol",singleR,3,31). bond("4α-formyl-ergosta-7,24(241)-dien-3β-ol",single,4,5).
+bond("4α-formyl-ergosta-7,24(241)-dien-3β-ol",singleS,4,28). bond("4α-formyl-ergosta-7,24(241)-dien-3β-ol",single,5,6). bond("4α-formyl-ergosta-7,24(241)-dien-3β-ol",single,5,10).
+bond("4α-formyl-ergosta-7,24(241)-dien-3β-ol",single,6,7). bond("4α-formyl-ergosta-7,24(241)-dien-3β-ol",double,7,8). bond("4α-formyl-ergosta-7,24(241)-dien-3β-ol",single,8,9).
+bond("4α-formyl-ergosta-7,24(241)-dien-3β-ol",single,8,14). bond("4α-formyl-ergosta-7,24(241)-dien-3β-ol",single,9,10). bond("4α-formyl-ergosta-7,24(241)-dien-3β-ol",single,9,11).
+bond("4α-formyl-ergosta-7,24(241)-dien-3β-ol",singleR,10,19). bond("4α-formyl-ergosta-7,24(241)-dien-3β-ol",single,11,12). bond("4α-formyl-ergosta-7,24(241)-dien-3β-ol",single,12,13).
+bond("4α-formyl-ergosta-7,24(241)-dien-3β-ol",single,13,14). bond("4α-formyl-ergosta-7,24(241)-dien-3β-ol",single,14,15). bond("4α-formyl-ergosta-7,24(241)-dien-3β-ol",single,15,16).
+bond("4α-formyl-ergosta-7,24(241)-dien-3β-ol",single,16,17). bond("4α-formyl-ergosta-7,24(241)-dien-3β-ol",single,13,17). bond("4α-formyl-ergosta-7,24(241)-dien-3β-ol",singleR,13,18).
+bond("4α-formyl-ergosta-7,24(241)-dien-3β-ol",singleR,17,20). bond("4α-formyl-ergosta-7,24(241)-dien-3β-ol",singleS,20,21). bond("4α-formyl-ergosta-7,24(241)-dien-3β-ol",single,20,22).
+bond("4α-formyl-ergosta-7,24(241)-dien-3β-ol",single,22,23). bond("4α-formyl-ergosta-7,24(241)-dien-3β-ol",single,23,24). bond("4α-formyl-ergosta-7,24(241)-dien-3β-ol",double,24,241).
+bond("4α-formyl-ergosta-7,24(241)-dien-3β-ol",single,24,25). bond("4α-formyl-ergosta-7,24(241)-dien-3β-ol",single,25,26). bond("4α-formyl-ergosta-7,24(241)-dien-3β-ol",single,25,27).
+bond("4α-formyl-ergosta-7,24(241)-dien-3β-ol",double,28,32).
+
+atom("4α-carboxy-ergosta-7,24(241)-dien-3β-ol",1..24,carb). atom("4α-carboxy-ergosta-7,24(241)-dien-3β-ol",241,carb). atom("4α-carboxy-ergosta-7,24(241)-dien-3β-ol",25..28,carb).
+atom("4α-carboxy-ergosta-7,24(241)-dien-3β-ol",31..33,oxyg).
+bond("4α-carboxy-ergosta-7,24(241)-dien-3β-ol",single,1,2). bond("4α-carboxy-ergosta-7,24(241)-dien-3β-ol",single,1,10). bond("4α-carboxy-ergosta-7,24(241)-dien-3β-ol",single,2,3).
+bond("4α-carboxy-ergosta-7,24(241)-dien-3β-ol",single,3,4). bond("4α-carboxy-ergosta-7,24(241)-dien-3β-ol",singleR,3,31). bond("4α-carboxy-ergosta-7,24(241)-dien-3β-ol",single,4,5).
+bond("4α-carboxy-ergosta-7,24(241)-dien-3β-ol",singleS,4,28). bond("4α-carboxy-ergosta-7,24(241)-dien-3β-ol",single,5,6). bond("4α-carboxy-ergosta-7,24(241)-dien-3β-ol",single,5,10).
+bond("4α-carboxy-ergosta-7,24(241)-dien-3β-ol",single,6,7). bond("4α-carboxy-ergosta-7,24(241)-dien-3β-ol",double,7,8). bond("4α-carboxy-ergosta-7,24(241)-dien-3β-ol",single,8,9).
+bond("4α-carboxy-ergosta-7,24(241)-dien-3β-ol",single,8,14). bond("4α-carboxy-ergosta-7,24(241)-dien-3β-ol",single,9,10). bond("4α-carboxy-ergosta-7,24(241)-dien-3β-ol",single,9,11).
+bond("4α-carboxy-ergosta-7,24(241)-dien-3β-ol",singleR,10,19). bond("4α-carboxy-ergosta-7,24(241)-dien-3β-ol",single,11,12). bond("4α-carboxy-ergosta-7,24(241)-dien-3β-ol",single,12,13).
+bond("4α-carboxy-ergosta-7,24(241)-dien-3β-ol",single,13,14). bond("4α-carboxy-ergosta-7,24(241)-dien-3β-ol",single,14,15). bond("4α-carboxy-ergosta-7,24(241)-dien-3β-ol",single,15,16).
+bond("4α-carboxy-ergosta-7,24(241)-dien-3β-ol",single,16,17). bond("4α-carboxy-ergosta-7,24(241)-dien-3β-ol",single,13,17). bond("4α-carboxy-ergosta-7,24(241)-dien-3β-ol",singleR,13,18).
+bond("4α-carboxy-ergosta-7,24(241)-dien-3β-ol",singleR,17,20). bond("4α-carboxy-ergosta-7,24(241)-dien-3β-ol",singleS,20,21). bond("4α-carboxy-ergosta-7,24(241)-dien-3β-ol",single,20,22).
+bond("4α-carboxy-ergosta-7,24(241)-dien-3β-ol",single,22,23). bond("4α-carboxy-ergosta-7,24(241)-dien-3β-ol",single,23,24). bond("4α-carboxy-ergosta-7,24(241)-dien-3β-ol",double,24,241).
+bond("4α-carboxy-ergosta-7,24(241)-dien-3β-ol",single,24,25). bond("4α-carboxy-ergosta-7,24(241)-dien-3β-ol",single,25,26). bond("4α-carboxy-ergosta-7,24(241)-dien-3β-ol",single,25,27).
+bond("4α-carboxy-ergosta-7,24(241)-dien-3β-ol",double,28,32). bond("4α-carboxy-ergosta-7,24(241)-dien-3β-ol",double,28,33).
+
+atom("episterone",1..24,carb). atom("episterone",241,carb). atom("episterone",25..27,carb).
+atom("episterone",31,oxyg).
+bond("episterone",single,1,2). bond("episterone",single,1,10). bond("episterone",single,2,3).
+bond("episterone",single,3,4). bond("episterone",double,3,31). bond("episterone",single,4,5).
+bond("episterone",single,5,6). bond("episterone",single,5,10). bond("episterone",single,6,7).
+bond("episterone",double,7,8). bond("episterone",single,8,9). bond("episterone",single,8,14).
+bond("episterone",single,9,10). bond("episterone",single,9,11). bond("episterone",singleR,10,19).
+bond("episterone",single,11,12). bond("episterone",single,12,13). bond("episterone",single,13,14).
+bond("episterone",single,14,15). bond("episterone",single,15,16). bond("episterone",single,16,17).
+bond("episterone",single,13,17). bond("episterone",singleR,13,18). bond("episterone",singleR,17,20).
+bond("episterone",singleS,20,21). bond("episterone",single,20,22). bond("episterone",single,22,23).
+bond("episterone",single,23,24). bond("episterone",double,24,241). bond("episterone",single,24,25).
+bond("episterone",single,25,26). bond("episterone",single,25,27).
+
+atom("episterol",1..24,carb). atom("episterol",241,carb). atom("episterol",25..27,carb).
+atom("episterol",31,oxyg).
+bond("episterol",single,1,2). bond("episterol",single,1,10). bond("episterol",single,2,3).
+bond("episterol",single,3,4). bond("episterol",singleR,3,31). bond("episterol",single,4,5).
+bond("episterol",single,5,6). bond("episterol",single,5,10). bond("episterol",single,6,7).
+bond("episterol",double,7,8). bond("episterol",single,8,9). bond("episterol",single,8,14).
+bond("episterol",single,9,10). bond("episterol",single,9,11). bond("episterol",singleR,10,19).
+bond("episterol",single,11,12). bond("episterol",single,12,13). bond("episterol",single,13,14).
+bond("episterol",single,14,15). bond("episterol",single,15,16). bond("episterol",single,16,17).
+bond("episterol",single,13,17). bond("episterol",singleR,13,18). bond("episterol",singleR,17,20).
+bond("episterol",singleS,20,21). bond("episterol",single,20,22). bond("episterol",single,22,23).
+bond("episterol",single,23,24). bond("episterol",double,24,241). bond("episterol",single,24,25).
+bond("episterol",single,25,26). bond("episterol",single,25,27).
+
+atom("ergosta-5,7,24(28)-trien-3β-ol",1..24,carb). atom("ergosta-5,7,24(28)-trien-3β-ol",241,carb). atom("ergosta-5,7,24(28)-trien-3β-ol",25..27,carb).
+atom("ergosta-5,7,24(28)-trien-3β-ol",31,oxyg).
+bond("ergosta-5,7,24(28)-trien-3β-ol",single,1,2). bond("ergosta-5,7,24(28)-trien-3β-ol",single,1,10). bond("ergosta-5,7,24(28)-trien-3β-ol",single,2,3).
+bond("ergosta-5,7,24(28)-trien-3β-ol",single,3,4). bond("ergosta-5,7,24(28)-trien-3β-ol",singleR,3,31). bond("ergosta-5,7,24(28)-trien-3β-ol",single,4,5).
+bond("ergosta-5,7,24(28)-trien-3β-ol",double,5,6). bond("ergosta-5,7,24(28)-trien-3β-ol",single,5,10). bond("ergosta-5,7,24(28)-trien-3β-ol",single,6,7).
+bond("ergosta-5,7,24(28)-trien-3β-ol",double,7,8). bond("ergosta-5,7,24(28)-trien-3β-ol",single,8,9). bond("ergosta-5,7,24(28)-trien-3β-ol",single,8,14).
+bond("ergosta-5,7,24(28)-trien-3β-ol",single,9,10). bond("ergosta-5,7,24(28)-trien-3β-ol",single,9,11). bond("ergosta-5,7,24(28)-trien-3β-ol",singleR,10,19).
+bond("ergosta-5,7,24(28)-trien-3β-ol",single,11,12). bond("ergosta-5,7,24(28)-trien-3β-ol",single,12,13). bond("ergosta-5,7,24(28)-trien-3β-ol",single,13,14).
+bond("ergosta-5,7,24(28)-trien-3β-ol",single,14,15). bond("ergosta-5,7,24(28)-trien-3β-ol",single,15,16). bond("ergosta-5,7,24(28)-trien-3β-ol",single,16,17).
+bond("ergosta-5,7,24(28)-trien-3β-ol",single,13,17). bond("ergosta-5,7,24(28)-trien-3β-ol",singleR,13,18). bond("ergosta-5,7,24(28)-trien-3β-ol",singleR,17,20).
+bond("ergosta-5,7,24(28)-trien-3β-ol",singleS,20,21). bond("ergosta-5,7,24(28)-trien-3β-ol",single,20,22). bond("ergosta-5,7,24(28)-trien-3β-ol",single,22,23).
+bond("ergosta-5,7,24(28)-trien-3β-ol",single,23,24). bond("ergosta-5,7,24(28)-trien-3β-ol",double,24,241). bond("ergosta-5,7,24(28)-trien-3β-ol",single,24,25).
+bond("ergosta-5,7,24(28)-trien-3β-ol",single,25,26). bond("ergosta-5,7,24(28)-trien-3β-ol",single,25,27).
+
+% Sterols from PWY-8191
+
+atom("(3β,9β)-4α-demethyl-4α-methylhydroxy-9,19-cyclolanost-24-en-3-ol",1..30,carb). atom("(3β,9β)-4α-demethyl-4α-methylhydroxy-9,19-cyclolanost-24-en-3-ol",31,oxyg). atom("(3β,9β)-4α-demethyl-4α-methylhydroxy-9,19-cyclolanost-24-en-3-ol",33,oxyg).
+bond("(3β,9β)-4α-demethyl-4α-methylhydroxy-9,19-cyclolanost-24-en-3-ol",single,1,2). bond("(3β,9β)-4α-demethyl-4α-methylhydroxy-9,19-cyclolanost-24-en-3-ol",single,1,10). bond("(3β,9β)-4α-demethyl-4α-methylhydroxy-9,19-cyclolanost-24-en-3-ol",single,2,3).
+bond("(3β,9β)-4α-demethyl-4α-methylhydroxy-9,19-cyclolanost-24-en-3-ol",single,3,4). bond("(3β,9β)-4α-demethyl-4α-methylhydroxy-9,19-cyclolanost-24-en-3-ol",singleR,3,31). bond("(3β,9β)-4α-demethyl-4α-methylhydroxy-9,19-cyclolanost-24-en-3-ol",single,4,5).
+bond("(3β,9β)-4α-demethyl-4α-methylhydroxy-9,19-cyclolanost-24-en-3-ol",singleR,4,29). bond("(3β,9β)-4α-demethyl-4α-methylhydroxy-9,19-cyclolanost-24-en-3-ol",singleS,4,28). bond("(3β,9β)-4α-demethyl-4α-methylhydroxy-9,19-cyclolanost-24-en-3-ol",single,5,6).
+bond("(3β,9β)-4α-demethyl-4α-methylhydroxy-9,19-cyclolanost-24-en-3-ol",single,5,10). bond("(3β,9β)-4α-demethyl-4α-methylhydroxy-9,19-cyclolanost-24-en-3-ol",single,6,7). bond("(3β,9β)-4α-demethyl-4α-methylhydroxy-9,19-cyclolanost-24-en-3-ol",single,7,8).
+bond("(3β,9β)-4α-demethyl-4α-methylhydroxy-9,19-cyclolanost-24-en-3-ol",single,8,9). bond("(3β,9β)-4α-demethyl-4α-methylhydroxy-9,19-cyclolanost-24-en-3-ol",single,8,14). bond("(3β,9β)-4α-demethyl-4α-methylhydroxy-9,19-cyclolanost-24-en-3-ol",single,9,10).
+bond("(3β,9β)-4α-demethyl-4α-methylhydroxy-9,19-cyclolanost-24-en-3-ol",single,9,11).bond("(3β,9β)-4α-demethyl-4α-methylhydroxy-9,19-cyclolanost-24-en-3-ol",singleR,9,19). bond("(3β,9β)-4α-demethyl-4α-methylhydroxy-9,19-cyclolanost-24-en-3-ol",singleR,10,19).
+bond("(3β,9β)-4α-demethyl-4α-methylhydroxy-9,19-cyclolanost-24-en-3-ol",single,11,12). bond("(3β,9β)-4α-demethyl-4α-methylhydroxy-9,19-cyclolanost-24-en-3-ol",single,12,13). bond("(3β,9β)-4α-demethyl-4α-methylhydroxy-9,19-cyclolanost-24-en-3-ol",single,13,14).
+bond("(3β,9β)-4α-demethyl-4α-methylhydroxy-9,19-cyclolanost-24-en-3-ol",single,14,15). bond("(3β,9β)-4α-demethyl-4α-methylhydroxy-9,19-cyclolanost-24-en-3-ol",singleS,14,30). bond("(3β,9β)-4α-demethyl-4α-methylhydroxy-9,19-cyclolanost-24-en-3-ol",single,15,16).
+bond("(3β,9β)-4α-demethyl-4α-methylhydroxy-9,19-cyclolanost-24-en-3-ol",single,16,17). bond("(3β,9β)-4α-demethyl-4α-methylhydroxy-9,19-cyclolanost-24-en-3-ol",single,13,17). bond("(3β,9β)-4α-demethyl-4α-methylhydroxy-9,19-cyclolanost-24-en-3-ol",singleR,13,18).
+bond("(3β,9β)-4α-demethyl-4α-methylhydroxy-9,19-cyclolanost-24-en-3-ol",singleR,17,20). bond("(3β,9β)-4α-demethyl-4α-methylhydroxy-9,19-cyclolanost-24-en-3-ol",singleS,20,21). bond("(3β,9β)-4α-demethyl-4α-methylhydroxy-9,19-cyclolanost-24-en-3-ol",single,20,22).
+bond("(3β,9β)-4α-demethyl-4α-methylhydroxy-9,19-cyclolanost-24-en-3-ol",single,22,23). bond("(3β,9β)-4α-demethyl-4α-methylhydroxy-9,19-cyclolanost-24-en-3-ol",single,23,24). bond("(3β,9β)-4α-demethyl-4α-methylhydroxy-9,19-cyclolanost-24-en-3-ol",double,24,25).
+bond("(3β,9β)-4α-demethyl-4α-methylhydroxy-9,19-cyclolanost-24-en-3-ol",single,25,26). bond("(3β,9β)-4α-demethyl-4α-methylhydroxy-9,19-cyclolanost-24-en-3-ol",single,25,27). bond("(3β,9β)-4α-demethyl-4α-methylhydroxy-9,19-cyclolanost-24-en-3-ol",single,29,33).
+
+atom("(3β,9β)-4α-demethyl-4α-formyl-9,19-cyclolanost-24-en-3-ol",1..30,carb). atom("(3β,9β)-4α-demethyl-4α-formyl-9,19-cyclolanost-24-en-3-ol",31,oxyg). atom("(3β,9β)-4α-demethyl-4α-formyl-9,19-cyclolanost-24-en-3-ol",33,oxyg).
+bond("(3β,9β)-4α-demethyl-4α-formyl-9,19-cyclolanost-24-en-3-ol",single,1,2). bond("(3β,9β)-4α-demethyl-4α-formyl-9,19-cyclolanost-24-en-3-ol",single,1,10). bond("(3β,9β)-4α-demethyl-4α-formyl-9,19-cyclolanost-24-en-3-ol",single,2,3).
+bond("(3β,9β)-4α-demethyl-4α-formyl-9,19-cyclolanost-24-en-3-ol",single,3,4). bond("(3β,9β)-4α-demethyl-4α-formyl-9,19-cyclolanost-24-en-3-ol",singleR,3,31). bond("(3β,9β)-4α-demethyl-4α-formyl-9,19-cyclolanost-24-en-3-ol",single,4,5).
+bond("(3β,9β)-4α-demethyl-4α-formyl-9,19-cyclolanost-24-en-3-ol",singleR,4,29). bond("(3β,9β)-4α-demethyl-4α-formyl-9,19-cyclolanost-24-en-3-ol",singleS,4,28). bond("(3β,9β)-4α-demethyl-4α-formyl-9,19-cyclolanost-24-en-3-ol",single,5,6).
+bond("(3β,9β)-4α-demethyl-4α-formyl-9,19-cyclolanost-24-en-3-ol",single,5,10). bond("(3β,9β)-4α-demethyl-4α-formyl-9,19-cyclolanost-24-en-3-ol",single,6,7). bond("(3β,9β)-4α-demethyl-4α-formyl-9,19-cyclolanost-24-en-3-ol",single,7,8).
+bond("(3β,9β)-4α-demethyl-4α-formyl-9,19-cyclolanost-24-en-3-ol",single,8,9). bond("(3β,9β)-4α-demethyl-4α-formyl-9,19-cyclolanost-24-en-3-ol",single,8,14). bond("(3β,9β)-4α-demethyl-4α-formyl-9,19-cyclolanost-24-en-3-ol",single,9,10).
+bond("(3β,9β)-4α-demethyl-4α-formyl-9,19-cyclolanost-24-en-3-ol",single,9,11).bond("(3β,9β)-4α-demethyl-4α-formyl-9,19-cyclolanost-24-en-3-ol",singleR,9,19). bond("(3β,9β)-4α-demethyl-4α-formyl-9,19-cyclolanost-24-en-3-ol",singleR,10,19).
+bond("(3β,9β)-4α-demethyl-4α-formyl-9,19-cyclolanost-24-en-3-ol",single,11,12). bond("(3β,9β)-4α-demethyl-4α-formyl-9,19-cyclolanost-24-en-3-ol",single,12,13). bond("(3β,9β)-4α-demethyl-4α-formyl-9,19-cyclolanost-24-en-3-ol",single,13,14).
+bond("(3β,9β)-4α-demethyl-4α-formyl-9,19-cyclolanost-24-en-3-ol",single,14,15). bond("(3β,9β)-4α-demethyl-4α-formyl-9,19-cyclolanost-24-en-3-ol",singleS,14,30). bond("(3β,9β)-4α-demethyl-4α-formyl-9,19-cyclolanost-24-en-3-ol",single,15,16).
+bond("(3β,9β)-4α-demethyl-4α-formyl-9,19-cyclolanost-24-en-3-ol",single,16,17). bond("(3β,9β)-4α-demethyl-4α-formyl-9,19-cyclolanost-24-en-3-ol",single,13,17). bond("(3β,9β)-4α-demethyl-4α-formyl-9,19-cyclolanost-24-en-3-ol",singleR,13,18).
+bond("(3β,9β)-4α-demethyl-4α-formyl-9,19-cyclolanost-24-en-3-ol",singleR,17,20). bond("(3β,9β)-4α-demethyl-4α-formyl-9,19-cyclolanost-24-en-3-ol",singleS,20,21). bond("(3β,9β)-4α-demethyl-4α-formyl-9,19-cyclolanost-24-en-3-ol",single,20,22).
+bond("(3β,9β)-4α-demethyl-4α-formyl-9,19-cyclolanost-24-en-3-ol",single,22,23). bond("(3β,9β)-4α-demethyl-4α-formyl-9,19-cyclolanost-24-en-3-ol",single,23,24). bond("(3β,9β)-4α-demethyl-4α-formyl-9,19-cyclolanost-24-en-3-ol",double,24,25).
+bond("(3β,9β)-4α-demethyl-4α-formyl-9,19-cyclolanost-24-en-3-ol",single,25,26). bond("(3β,9β)-4α-demethyl-4α-formyl-9,19-cyclolanost-24-en-3-ol",single,25,27). bond("(3β,9β)-4α-demethyl-4α-formyl-9,19-cyclolanost-24-en-3-ol",double,29,33).
+
+atom("(3β,9β)-4α-demethyl-4α-carboxy-9,19-cyclolanost-24-en-3-ol",1..30,carb). atom("(3β,9β)-4α-demethyl-4α-carboxy-9,19-cyclolanost-24-en-3-ol",31..33,oxyg).
+bond("(3β,9β)-4α-demethyl-4α-carboxy-9,19-cyclolanost-24-en-3-ol",single,1,2). bond("(3β,9β)-4α-demethyl-4α-carboxy-9,19-cyclolanost-24-en-3-ol",single,1,10). bond("(3β,9β)-4α-demethyl-4α-carboxy-9,19-cyclolanost-24-en-3-ol",single,2,3).
+bond("(3β,9β)-4α-demethyl-4α-carboxy-9,19-cyclolanost-24-en-3-ol",single,3,4). bond("(3β,9β)-4α-demethyl-4α-carboxy-9,19-cyclolanost-24-en-3-ol",singleR,3,31). bond("(3β,9β)-4α-demethyl-4α-carboxy-9,19-cyclolanost-24-en-3-ol",single,4,5).
+bond("(3β,9β)-4α-demethyl-4α-carboxy-9,19-cyclolanost-24-en-3-ol",singleR,4,29). bond("(3β,9β)-4α-demethyl-4α-carboxy-9,19-cyclolanost-24-en-3-ol",singleS,4,28). bond("(3β,9β)-4α-demethyl-4α-carboxy-9,19-cyclolanost-24-en-3-ol",single,5,6).
+bond("(3β,9β)-4α-demethyl-4α-carboxy-9,19-cyclolanost-24-en-3-ol",single,5,10). bond("(3β,9β)-4α-demethyl-4α-carboxy-9,19-cyclolanost-24-en-3-ol",single,6,7). bond("(3β,9β)-4α-demethyl-4α-carboxy-9,19-cyclolanost-24-en-3-ol",single,7,8).
+bond("(3β,9β)-4α-demethyl-4α-carboxy-9,19-cyclolanost-24-en-3-ol",single,8,9). bond("(3β,9β)-4α-demethyl-4α-carboxy-9,19-cyclolanost-24-en-3-ol",single,8,14). bond("(3β,9β)-4α-demethyl-4α-carboxy-9,19-cyclolanost-24-en-3-ol",single,9,10).
+bond("(3β,9β)-4α-demethyl-4α-carboxy-9,19-cyclolanost-24-en-3-ol",single,9,11).bond("(3β,9β)-4α-demethyl-4α-carboxy-9,19-cyclolanost-24-en-3-ol",singleR,9,19). bond("(3β,9β)-4α-demethyl-4α-carboxy-9,19-cyclolanost-24-en-3-ol",singleR,10,19).
+bond("(3β,9β)-4α-demethyl-4α-carboxy-9,19-cyclolanost-24-en-3-ol",single,11,12). bond("(3β,9β)-4α-demethyl-4α-carboxy-9,19-cyclolanost-24-en-3-ol",single,12,13). bond("(3β,9β)-4α-demethyl-4α-carboxy-9,19-cyclolanost-24-en-3-ol",single,13,14).
+bond("(3β,9β)-4α-demethyl-4α-carboxy-9,19-cyclolanost-24-en-3-ol",single,14,15). bond("(3β,9β)-4α-demethyl-4α-carboxy-9,19-cyclolanost-24-en-3-ol",singleS,14,30). bond("(3β,9β)-4α-demethyl-4α-carboxy-9,19-cyclolanost-24-en-3-ol",single,15,16).
+bond("(3β,9β)-4α-demethyl-4α-carboxy-9,19-cyclolanost-24-en-3-ol",single,16,17). bond("(3β,9β)-4α-demethyl-4α-carboxy-9,19-cyclolanost-24-en-3-ol",single,13,17). bond("(3β,9β)-4α-demethyl-4α-carboxy-9,19-cyclolanost-24-en-3-ol",singleR,13,18).
+bond("(3β,9β)-4α-demethyl-4α-carboxy-9,19-cyclolanost-24-en-3-ol",singleR,17,20). bond("(3β,9β)-4α-demethyl-4α-carboxy-9,19-cyclolanost-24-en-3-ol",singleS,20,21). bond("(3β,9β)-4α-demethyl-4α-carboxy-9,19-cyclolanost-24-en-3-ol",single,20,22).
+bond("(3β,9β)-4α-demethyl-4α-carboxy-9,19-cyclolanost-24-en-3-ol",single,22,23). bond("(3β,9β)-4α-demethyl-4α-carboxy-9,19-cyclolanost-24-en-3-ol",single,23,24). bond("(3β,9β)-4α-demethyl-4α-carboxy-9,19-cyclolanost-24-en-3-ol",double,24,25).
+bond("(3β,9β)-4α-demethyl-4α-carboxy-9,19-cyclolanost-24-en-3-ol",single,25,26). bond("(3β,9β)-4α-demethyl-4α-carboxy-9,19-cyclolanost-24-en-3-ol",single,25,27). bond("(3β,9β)-4α-demethyl-4α-carboxy-9,19-cyclolanost-24-en-3-ol",single,29,32).
+bond("(3β,9β)-4α-demethyl-4α-carboxy-9,19-cyclolanost-24-en-3-ol",double,29,33).
+
+atom("31-norcycloartenone",1..28,carb). atom("31-norcycloartenone",30,carb). atom("31-norcycloartenone",31,oxyg).
+bond("31-norcycloartenone",single,1,2). bond("31-norcycloartenone",single,1,10). bond("31-norcycloartenone",single,2,3).
+bond("31-norcycloartenone",single,3,4). bond("31-norcycloartenone",double,3,31). bond("31-norcycloartenone",single,4,5).
+bond("31-norcycloartenone",singleS,4,28). bond("31-norcycloartenone",single,5,6). bond("31-norcycloartenone",single,5,10).
+bond("31-norcycloartenone",single,6,7). bond("31-norcycloartenone",single,7,8). bond("31-norcycloartenone",single,8,9).
+bond("31-norcycloartenone",single,8,14). bond("31-norcycloartenone",single,9,10). bond("31-norcycloartenone",single,9,11).
+bond("31-norcycloartenone",singleR,9,19). bond("31-norcycloartenone",singleR,10,19). bond("31-norcycloartenone",single,11,12).
+bond("31-norcycloartenone",single,12,13). bond("31-norcycloartenone",single,13,14). bond("31-norcycloartenone",single,14,15).
+bond("31-norcycloartenone",singleS,14,30). bond("31-norcycloartenone",single,15,16). bond("31-norcycloartenone",single,16,17).
+bond("31-norcycloartenone",single,13,17). bond("31-norcycloartenone",singleR,13,18). bond("31-norcycloartenone",singleR,17,20).
+bond("31-norcycloartenone",singleS,20,21). bond("31-norcycloartenone",single,20,22). bond("31-norcycloartenone",single,22,23).
+bond("31-norcycloartenone",single,23,24). bond("31-norcycloartenone",double,24,25). bond("31-norcycloartenone",single,25,26).
+bond("31-norcycloartenone",single,25,27).
+
+atom("31-norcycloartenol",1..28,carb). atom("31-norcycloartenol",30,carb). atom("31-norcycloartenol",31,oxyg).
+bond("31-norcycloartenol",single,1,2). bond("31-norcycloartenol",single,1,10). bond("31-norcycloartenol",single,2,3).
+bond("31-norcycloartenol",single,3,4). bond("31-norcycloartenol",double,3,31). bond("31-norcycloartenol",single,4,5).
+bond("31-norcycloartenol",singleS,4,28). bond("31-norcycloartenol",single,5,6). bond("31-norcycloartenol",single,5,10).
+bond("31-norcycloartenol",single,6,7). bond("31-norcycloartenol",single,7,8). bond("31-norcycloartenol",double,8,9).
+bond("31-norcycloartenol",single,8,14). bond("31-norcycloartenol",single,9,10). bond("31-norcycloartenol",single,9,11).
+bond("31-norcycloartenol",singleR,10,19). bond("31-norcycloartenol",single,11,12). bond("31-norcycloartenol",single,12,13).
+bond("31-norcycloartenol",single,13,14). bond("31-norcycloartenol",single,14,15). bond("31-norcycloartenol",single,15,16).
+bond("31-norcycloartenol",single,16,17). bond("31-norcycloartenol",single,13,17). bond("31-norcycloartenol",singleR,13,18).
+bond("31-norcycloartenol",singleR,17,20). bond("31-norcycloartenol",singleS,20,21). bond("31-norcycloartenol",single,20,22).
+bond("31-norcycloartenol",single,22,23). bond("31-norcycloartenol",single,23,24). bond("31-norcycloartenol",double,24,25).
+bond("31-norcycloartenol",single,25,26). bond("31-norcycloartenol",single,25,27).
+
+atom("4α,14α-dimethyl-5α-cholesta-8,24-dien-3β-ol",1..28,carb). atom("4α,14α-dimethyl-5α-cholesta-8,24-dien-3β-ol",30,carb). atom("4α,14α-dimethyl-5α-cholesta-8,24-dien-3β-ol",31,oxyg).
+bond("4α,14α-dimethyl-5α-cholesta-8,24-dien-3β-ol",single,1,2). bond("4α,14α-dimethyl-5α-cholesta-8,24-dien-3β-ol",single,1,10). bond("4α,14α-dimethyl-5α-cholesta-8,24-dien-3β-ol",single,2,3).
+bond("4α,14α-dimethyl-5α-cholesta-8,24-dien-3β-ol",single,3,4). bond("4α,14α-dimethyl-5α-cholesta-8,24-dien-3β-ol",double,3,31). bond("4α,14α-dimethyl-5α-cholesta-8,24-dien-3β-ol",single,4,5).
+bond("4α,14α-dimethyl-5α-cholesta-8,24-dien-3β-ol",singleS,4,28). bond("4α,14α-dimethyl-5α-cholesta-8,24-dien-3β-ol",single,5,6). bond("4α,14α-dimethyl-5α-cholesta-8,24-dien-3β-ol",single,5,10).
+bond("4α,14α-dimethyl-5α-cholesta-8,24-dien-3β-ol",single,6,7). bond("4α,14α-dimethyl-5α-cholesta-8,24-dien-3β-ol",single,7,8). bond("4α,14α-dimethyl-5α-cholesta-8,24-dien-3β-ol",double,8,9).
+bond("4α,14α-dimethyl-5α-cholesta-8,24-dien-3β-ol",single,8,14). bond("4α,14α-dimethyl-5α-cholesta-8,24-dien-3β-ol",single,9,10). bond("4α,14α-dimethyl-5α-cholesta-8,24-dien-3β-ol",single,9,11).
+bond("4α,14α-dimethyl-5α-cholesta-8,24-dien-3β-ol",singleR,10,19). bond("4α,14α-dimethyl-5α-cholesta-8,24-dien-3β-ol",single,11,12). bond("4α,14α-dimethyl-5α-cholesta-8,24-dien-3β-ol",single,12,13).
+bond("4α,14α-dimethyl-5α-cholesta-8,24-dien-3β-ol",single,13,14). bond("4α,14α-dimethyl-5α-cholesta-8,24-dien-3β-ol",single,14,15). bond("4α,14α-dimethyl-5α-cholesta-8,24-dien-3β-ol",single,15,16).
+bond("4α,14α-dimethyl-5α-cholesta-8,24-dien-3β-ol",single,16,17). bond("4α,14α-dimethyl-5α-cholesta-8,24-dien-3β-ol",single,13,17). bond("4α,14α-dimethyl-5α-cholesta-8,24-dien-3β-ol",singleR,13,18).
+bond("4α,14α-dimethyl-5α-cholesta-8,24-dien-3β-ol",singleR,17,20). bond("4α,14α-dimethyl-5α-cholesta-8,24-dien-3β-ol",singleS,20,21). bond("4α,14α-dimethyl-5α-cholesta-8,24-dien-3β-ol",single,20,22).
+bond("4α,14α-dimethyl-5α-cholesta-8,24-dien-3β-ol",single,22,23). bond("4α,14α-dimethyl-5α-cholesta-8,24-dien-3β-ol",single,23,24). bond("4α,14α-dimethyl-5α-cholesta-8,24-dien-3β-ol",double,24,25).
+bond("4α,14α-dimethyl-5α-cholesta-8,24-dien-3β-ol",single,25,26). bond("4α,14α-dimethyl-5α-cholesta-8,24-dien-3β-ol",single,25,27).
+
+atom("4α-hydroxymethyl-14α-methyl-5α-cholesta-8,24-dien-3β-ol",1..28,carb). atom("4α-hydroxymethyl-14α-methyl-5α-cholesta-8,24-dien-3β-ol",30,carb). atom("4α-hydroxymethyl-14α-methyl-5α-cholesta-8,24-dien-3β-ol",31,oxyg).
+atom("4α-hydroxymethyl-14α-methyl-5α-cholesta-8,24-dien-3β-ol",34,oxyg).
+bond("4α-hydroxymethyl-14α-methyl-5α-cholesta-8,24-dien-3β-ol",single,1,2). bond("4α-hydroxymethyl-14α-methyl-5α-cholesta-8,24-dien-3β-ol",single,1,10). bond("4α-hydroxymethyl-14α-methyl-5α-cholesta-8,24-dien-3β-ol",single,2,3).
+bond("4α-hydroxymethyl-14α-methyl-5α-cholesta-8,24-dien-3β-ol",single,3,4). bond("4α-hydroxymethyl-14α-methyl-5α-cholesta-8,24-dien-3β-ol",double,3,31). bond("4α-hydroxymethyl-14α-methyl-5α-cholesta-8,24-dien-3β-ol",single,4,5).
+bond("4α-hydroxymethyl-14α-methyl-5α-cholesta-8,24-dien-3β-ol",singleS,4,28). bond("4α-hydroxymethyl-14α-methyl-5α-cholesta-8,24-dien-3β-ol",single,5,6). bond("4α-hydroxymethyl-14α-methyl-5α-cholesta-8,24-dien-3β-ol",single,5,10).
+bond("4α-hydroxymethyl-14α-methyl-5α-cholesta-8,24-dien-3β-ol",single,6,7). bond("4α-hydroxymethyl-14α-methyl-5α-cholesta-8,24-dien-3β-ol",single,7,8). bond("4α-hydroxymethyl-14α-methyl-5α-cholesta-8,24-dien-3β-ol",double,8,9).
+bond("4α-hydroxymethyl-14α-methyl-5α-cholesta-8,24-dien-3β-ol",single,8,14). bond("4α-hydroxymethyl-14α-methyl-5α-cholesta-8,24-dien-3β-ol",single,9,10). bond("4α-hydroxymethyl-14α-methyl-5α-cholesta-8,24-dien-3β-ol",single,9,11).
+bond("4α-hydroxymethyl-14α-methyl-5α-cholesta-8,24-dien-3β-ol",singleR,10,19). bond("4α-hydroxymethyl-14α-methyl-5α-cholesta-8,24-dien-3β-ol",single,11,12). bond("4α-hydroxymethyl-14α-methyl-5α-cholesta-8,24-dien-3β-ol",single,12,13).
+bond("4α-hydroxymethyl-14α-methyl-5α-cholesta-8,24-dien-3β-ol",single,13,14). bond("4α-hydroxymethyl-14α-methyl-5α-cholesta-8,24-dien-3β-ol",single,14,15). bond("4α-hydroxymethyl-14α-methyl-5α-cholesta-8,24-dien-3β-ol",single,15,16).
+bond("4α-hydroxymethyl-14α-methyl-5α-cholesta-8,24-dien-3β-ol",single,16,17). bond("4α-hydroxymethyl-14α-methyl-5α-cholesta-8,24-dien-3β-ol",single,13,17). bond("4α-hydroxymethyl-14α-methyl-5α-cholesta-8,24-dien-3β-ol",singleR,13,18).
+bond("4α-hydroxymethyl-14α-methyl-5α-cholesta-8,24-dien-3β-ol",singleR,17,20). bond("4α-hydroxymethyl-14α-methyl-5α-cholesta-8,24-dien-3β-ol",singleS,20,21). bond("4α-hydroxymethyl-14α-methyl-5α-cholesta-8,24-dien-3β-ol",single,20,22).
+bond("4α-hydroxymethyl-14α-methyl-5α-cholesta-8,24-dien-3β-ol",single,22,23). bond("4α-hydroxymethyl-14α-methyl-5α-cholesta-8,24-dien-3β-ol",single,23,24). bond("4α-hydroxymethyl-14α-methyl-5α-cholesta-8,24-dien-3β-ol",double,24,25).
+bond("4α-hydroxymethyl-14α-methyl-5α-cholesta-8,24-dien-3β-ol",single,25,26). bond("4α-hydroxymethyl-14α-methyl-5α-cholesta-8,24-dien-3β-ol",single,25,27). bond("4α-hydroxymethyl-14α-methyl-5α-cholesta-8,24-dien-3β-ol",single,29,34).
+
+atom("4α-formyl-14α-methyl-5α-cholesta-8,24-dien-3β-ol",1..28,carb). atom("4α-formyl-14α-methyl-5α-cholesta-8,24-dien-3β-ol",30,carb). atom("4α-formyl-14α-methyl-5α-cholesta-8,24-dien-3β-ol",31,oxyg).
+atom("4α-formyl-14α-methyl-5α-cholesta-8,24-dien-3β-ol",34,oxyg).
+bond("4α-formyl-14α-methyl-5α-cholesta-8,24-dien-3β-ol",single,1,2). bond("4α-formyl-14α-methyl-5α-cholesta-8,24-dien-3β-ol",single,1,10). bond("4α-formyl-14α-methyl-5α-cholesta-8,24-dien-3β-ol",single,2,3).
+bond("4α-formyl-14α-methyl-5α-cholesta-8,24-dien-3β-ol",single,3,4). bond("4α-formyl-14α-methyl-5α-cholesta-8,24-dien-3β-ol",double,3,31). bond("4α-formyl-14α-methyl-5α-cholesta-8,24-dien-3β-ol",single,4,5).
+bond("4α-formyl-14α-methyl-5α-cholesta-8,24-dien-3β-ol",singleS,4,28). bond("4α-formyl-14α-methyl-5α-cholesta-8,24-dien-3β-ol",single,5,6). bond("4α-formyl-14α-methyl-5α-cholesta-8,24-dien-3β-ol",single,5,10).
+bond("4α-formyl-14α-methyl-5α-cholesta-8,24-dien-3β-ol",single,6,7). bond("4α-formyl-14α-methyl-5α-cholesta-8,24-dien-3β-ol",single,7,8). bond("4α-formyl-14α-methyl-5α-cholesta-8,24-dien-3β-ol",double,8,9).
+bond("4α-formyl-14α-methyl-5α-cholesta-8,24-dien-3β-ol",single,8,14). bond("4α-formyl-14α-methyl-5α-cholesta-8,24-dien-3β-ol",single,9,10). bond("4α-formyl-14α-methyl-5α-cholesta-8,24-dien-3β-ol",single,9,11).
+bond("4α-formyl-14α-methyl-5α-cholesta-8,24-dien-3β-ol",singleR,10,19). bond("4α-formyl-14α-methyl-5α-cholesta-8,24-dien-3β-ol",single,11,12). bond("4α-formyl-14α-methyl-5α-cholesta-8,24-dien-3β-ol",single,12,13).
+bond("4α-formyl-14α-methyl-5α-cholesta-8,24-dien-3β-ol",single,13,14). bond("4α-formyl-14α-methyl-5α-cholesta-8,24-dien-3β-ol",single,14,15). bond("4α-formyl-14α-methyl-5α-cholesta-8,24-dien-3β-ol",single,15,16).
+bond("4α-formyl-14α-methyl-5α-cholesta-8,24-dien-3β-ol",single,16,17). bond("4α-formyl-14α-methyl-5α-cholesta-8,24-dien-3β-ol",single,13,17). bond("4α-formyl-14α-methyl-5α-cholesta-8,24-dien-3β-ol",singleR,13,18).
+bond("4α-formyl-14α-methyl-5α-cholesta-8,24-dien-3β-ol",singleR,17,20). bond("4α-formyl-14α-methyl-5α-cholesta-8,24-dien-3β-ol",singleS,20,21). bond("4α-formyl-14α-methyl-5α-cholesta-8,24-dien-3β-ol",single,20,22).
+bond("4α-formyl-14α-methyl-5α-cholesta-8,24-dien-3β-ol",single,22,23). bond("4α-formyl-14α-methyl-5α-cholesta-8,24-dien-3β-ol",single,23,24). bond("4α-formyl-14α-methyl-5α-cholesta-8,24-dien-3β-ol",double,24,25).
+bond("4α-formyl-14α-methyl-5α-cholesta-8,24-dien-3β-ol",single,25,26). bond("4α-formyl-14α-methyl-5α-cholesta-8,24-dien-3β-ol",single,25,27). bond("4α-formyl-14α-methyl-5α-cholesta-8,24-dien-3β-ol",double,29,34).
+
+atom("4α-methyl-5α-cholesta-8,14,24-trien-3β-ol",1..28,carb). atom("4α-methyl-5α-cholesta-8,14,24-trien-3β-ol",31,oxyg).
+bond("4α-methyl-5α-cholesta-8,14,24-trien-3β-ol",single,1,2). bond("4α-methyl-5α-cholesta-8,14,24-trien-3β-ol",single,1,10). bond("4α-methyl-5α-cholesta-8,14,24-trien-3β-ol",single,2,3).
+bond("4α-methyl-5α-cholesta-8,14,24-trien-3β-ol",single,3,4). bond("4α-methyl-5α-cholesta-8,14,24-trien-3β-ol",double,3,31). bond("4α-methyl-5α-cholesta-8,14,24-trien-3β-ol",single,4,5).
+bond("4α-methyl-5α-cholesta-8,14,24-trien-3β-ol",singleS,4,28). bond("4α-methyl-5α-cholesta-8,14,24-trien-3β-ol",single,5,6). bond("4α-methyl-5α-cholesta-8,14,24-trien-3β-ol",single,5,10).
+bond("4α-methyl-5α-cholesta-8,14,24-trien-3β-ol",single,6,7). bond("4α-methyl-5α-cholesta-8,14,24-trien-3β-ol",single,7,8). bond("4α-methyl-5α-cholesta-8,14,24-trien-3β-ol",double,8,9).
+bond("4α-methyl-5α-cholesta-8,14,24-trien-3β-ol",single,8,14). bond("4α-methyl-5α-cholesta-8,14,24-trien-3β-ol",single,9,10). bond("4α-methyl-5α-cholesta-8,14,24-trien-3β-ol",single,9,11).
+bond("4α-methyl-5α-cholesta-8,14,24-trien-3β-ol",singleR,10,19). bond("4α-methyl-5α-cholesta-8,14,24-trien-3β-ol",single,11,12). bond("4α-methyl-5α-cholesta-8,14,24-trien-3β-ol",single,12,13).
+bond("4α-methyl-5α-cholesta-8,14,24-trien-3β-ol",single,13,14). bond("4α-methyl-5α-cholesta-8,14,24-trien-3β-ol",double,14,15). bond("4α-methyl-5α-cholesta-8,14,24-trien-3β-ol",single,15,16).
+bond("4α-methyl-5α-cholesta-8,14,24-trien-3β-ol",single,16,17). bond("4α-methyl-5α-cholesta-8,14,24-trien-3β-ol",single,13,17). bond("4α-methyl-5α-cholesta-8,14,24-trien-3β-ol",singleR,13,18).
+bond("4α-methyl-5α-cholesta-8,14,24-trien-3β-ol",singleR,17,20). bond("4α-methyl-5α-cholesta-8,14,24-trien-3β-ol",singleS,20,21). bond("4α-methyl-5α-cholesta-8,14,24-trien-3β-ol",single,20,22).
+bond("4α-methyl-5α-cholesta-8,14,24-trien-3β-ol",single,22,23). bond("4α-methyl-5α-cholesta-8,14,24-trien-3β-ol",single,23,24). bond("4α-methyl-5α-cholesta-8,14,24-trien-3β-ol",double,24,25).
+bond("4α-methyl-5α-cholesta-8,14,24-trien-3β-ol",single,25,26). bond("4α-methyl-5α-cholesta-8,14,24-trien-3β-ol",single,25,27).
+
+atom("4α-methyl-5α-cholesta-8,24-dien-3β-ol",1..28,carb). atom("4α-methyl-5α-cholesta-8,24-dien-3β-ol",31,oxyg).
+bond("4α-methyl-5α-cholesta-8,24-dien-3β-ol",single,1,2). bond("4α-methyl-5α-cholesta-8,24-dien-3β-ol",single,1,10). bond("4α-methyl-5α-cholesta-8,24-dien-3β-ol",single,2,3).
+bond("4α-methyl-5α-cholesta-8,24-dien-3β-ol",single,3,4). bond("4α-methyl-5α-cholesta-8,24-dien-3β-ol",double,3,31). bond("4α-methyl-5α-cholesta-8,24-dien-3β-ol",single,4,5).
+bond("4α-methyl-5α-cholesta-8,24-dien-3β-ol",singleS,4,28). bond("4α-methyl-5α-cholesta-8,24-dien-3β-ol",single,5,6). bond("4α-methyl-5α-cholesta-8,24-dien-3β-ol",single,5,10).
+bond("4α-methyl-5α-cholesta-8,24-dien-3β-ol",single,6,7). bond("4α-methyl-5α-cholesta-8,24-dien-3β-ol",single,7,8). bond("4α-methyl-5α-cholesta-8,24-dien-3β-ol",double,8,9).
+bond("4α-methyl-5α-cholesta-8,24-dien-3β-ol",single,8,14). bond("4α-methyl-5α-cholesta-8,24-dien-3β-ol",single,9,10). bond("4α-methyl-5α-cholesta-8,24-dien-3β-ol",single,9,11).
+bond("4α-methyl-5α-cholesta-8,24-dien-3β-ol",singleR,10,19). bond("4α-methyl-5α-cholesta-8,24-dien-3β-ol",single,11,12). bond("4α-methyl-5α-cholesta-8,24-dien-3β-ol",single,12,13).
+bond("4α-methyl-5α-cholesta-8,24-dien-3β-ol",single,13,14). bond("4α-methyl-5α-cholesta-8,24-dien-3β-ol",single,14,15). bond("4α-methyl-5α-cholesta-8,24-dien-3β-ol",single,15,16).
+bond("4α-methyl-5α-cholesta-8,24-dien-3β-ol",single,16,17). bond("4α-methyl-5α-cholesta-8,24-dien-3β-ol",single,13,17). bond("4α-methyl-5α-cholesta-8,24-dien-3β-ol",singleR,13,18).
+bond("4α-methyl-5α-cholesta-8,24-dien-3β-ol",singleR,17,20). bond("4α-methyl-5α-cholesta-8,24-dien-3β-ol",singleS,20,21). bond("4α-methyl-5α-cholesta-8,24-dien-3β-ol",single,20,22).
+bond("4α-methyl-5α-cholesta-8,24-dien-3β-ol",single,22,23). bond("4α-methyl-5α-cholesta-8,24-dien-3β-ol",single,23,24). bond("4α-methyl-5α-cholesta-8,24-dien-3β-ol",double,24,25).
+bond("4α-methyl-5α-cholesta-8,24-dien-3β-ol",single,25,26). bond("4α-methyl-5α-cholesta-8,24-dien-3β-ol",single,25,27).
+
+atom("4α-methyl-5α-cholesta-7,24-dien-3β-ol",1..28,carb). atom("4α-methyl-5α-cholesta-7,24-dien-3β-ol",31,oxyg).
+bond("4α-methyl-5α-cholesta-7,24-dien-3β-ol",single,1,2). bond("4α-methyl-5α-cholesta-7,24-dien-3β-ol",single,1,10). bond("4α-methyl-5α-cholesta-7,24-dien-3β-ol",single,2,3).
+bond("4α-methyl-5α-cholesta-7,24-dien-3β-ol",single,3,4). bond("4α-methyl-5α-cholesta-7,24-dien-3β-ol",double,3,31). bond("4α-methyl-5α-cholesta-7,24-dien-3β-ol",single,4,5).
+bond("4α-methyl-5α-cholesta-7,24-dien-3β-ol",singleS,4,28). bond("4α-methyl-5α-cholesta-7,24-dien-3β-ol",single,5,6). bond("4α-methyl-5α-cholesta-7,24-dien-3β-ol",single,5,10).
+bond("4α-methyl-5α-cholesta-7,24-dien-3β-ol",single,6,7). bond("4α-methyl-5α-cholesta-7,24-dien-3β-ol",double,7,8). bond("4α-methyl-5α-cholesta-7,24-dien-3β-ol",single,8,9).
+bond("4α-methyl-5α-cholesta-7,24-dien-3β-ol",single,8,14). bond("4α-methyl-5α-cholesta-7,24-dien-3β-ol",single,9,10). bond("4α-methyl-5α-cholesta-7,24-dien-3β-ol",single,9,11).
+bond("4α-methyl-5α-cholesta-7,24-dien-3β-ol",singleR,10,19). bond("4α-methyl-5α-cholesta-7,24-dien-3β-ol",single,11,12). bond("4α-methyl-5α-cholesta-7,24-dien-3β-ol",single,12,13).
+bond("4α-methyl-5α-cholesta-7,24-dien-3β-ol",single,13,14). bond("4α-methyl-5α-cholesta-7,24-dien-3β-ol",single,14,15). bond("4α-methyl-5α-cholesta-7,24-dien-3β-ol",single,15,16).
+bond("4α-methyl-5α-cholesta-7,24-dien-3β-ol",single,16,17). bond("4α-methyl-5α-cholesta-7,24-dien-3β-ol",single,13,17). bond("4α-methyl-5α-cholesta-7,24-dien-3β-ol",singleR,13,18).
+bond("4α-methyl-5α-cholesta-7,24-dien-3β-ol",singleR,17,20). bond("4α-methyl-5α-cholesta-7,24-dien-3β-ol",singleS,20,21). bond("4α-methyl-5α-cholesta-7,24-dien-3β-ol",single,20,22).
+bond("4α-methyl-5α-cholesta-7,24-dien-3β-ol",single,22,23). bond("4α-methyl-5α-cholesta-7,24-dien-3β-ol",single,23,24). bond("4α-methyl-5α-cholesta-7,24-dien-3β-ol",double,24,25).
+bond("4α-methyl-5α-cholesta-7,24-dien-3β-ol",single,25,26). bond("4α-methyl-5α-cholesta-7,24-dien-3β-ol",single,25,27).
+
+atom("4α-methylhydroxy-5α-cholest-7,24-dien-3β-ol",1..28,carb). atom("4α-methylhydroxy-5α-cholest-7,24-dien-3β-ol",31,oxyg). atom("4α-methylhydroxy-5α-cholest-7,24-dien-3β-ol",34,oxyg).
+bond("4α-methylhydroxy-5α-cholest-7,24-dien-3β-ol",single,1,2). bond("4α-methylhydroxy-5α-cholest-7,24-dien-3β-ol",single,1,10). bond("4α-methylhydroxy-5α-cholest-7,24-dien-3β-ol",single,2,3).
+bond("4α-methylhydroxy-5α-cholest-7,24-dien-3β-ol",single,3,4). bond("4α-methylhydroxy-5α-cholest-7,24-dien-3β-ol",double,3,31). bond("4α-methylhydroxy-5α-cholest-7,24-dien-3β-ol",single,4,5).
+bond("4α-methylhydroxy-5α-cholest-7,24-dien-3β-ol",singleS,4,28). bond("4α-methylhydroxy-5α-cholest-7,24-dien-3β-ol",single,5,6). bond("4α-methylhydroxy-5α-cholest-7,24-dien-3β-ol",single,5,10).
+bond("4α-methylhydroxy-5α-cholest-7,24-dien-3β-ol",single,6,7). bond("4α-methylhydroxy-5α-cholest-7,24-dien-3β-ol",double,7,8). bond("4α-methylhydroxy-5α-cholest-7,24-dien-3β-ol",single,8,9).
+bond("4α-methylhydroxy-5α-cholest-7,24-dien-3β-ol",single,8,14). bond("4α-methylhydroxy-5α-cholest-7,24-dien-3β-ol",single,9,10). bond("4α-methylhydroxy-5α-cholest-7,24-dien-3β-ol",single,9,11).
+bond("4α-methylhydroxy-5α-cholest-7,24-dien-3β-ol",singleR,10,19). bond("4α-methylhydroxy-5α-cholest-7,24-dien-3β-ol",single,11,12). bond("4α-methylhydroxy-5α-cholest-7,24-dien-3β-ol",single,12,13).
+bond("4α-methylhydroxy-5α-cholest-7,24-dien-3β-ol",single,13,14). bond("4α-methylhydroxy-5α-cholest-7,24-dien-3β-ol",single,14,15). bond("4α-methylhydroxy-5α-cholest-7,24-dien-3β-ol",single,15,16).
+bond("4α-methylhydroxy-5α-cholest-7,24-dien-3β-ol",single,16,17). bond("4α-methylhydroxy-5α-cholest-7,24-dien-3β-ol",single,13,17). bond("4α-methylhydroxy-5α-cholest-7,24-dien-3β-ol",singleR,13,18).
+bond("4α-methylhydroxy-5α-cholest-7,24-dien-3β-ol",singleR,17,20). bond("4α-methylhydroxy-5α-cholest-7,24-dien-3β-ol",singleS,20,21). bond("4α-methylhydroxy-5α-cholest-7,24-dien-3β-ol",single,20,22).
+bond("4α-methylhydroxy-5α-cholest-7,24-dien-3β-ol",single,22,23). bond("4α-methylhydroxy-5α-cholest-7,24-dien-3β-ol",single,23,24). bond("4α-methylhydroxy-5α-cholest-7,24-dien-3β-ol",double,24,25).
+bond("4α-methylhydroxy-5α-cholest-7,24-dien-3β-ol",single,25,26). bond("4α-methylhydroxy-5α-cholest-7,24-dien-3β-ol",single,25,27). bond("4α-methylhydroxy-5α-cholest-7,24-dien-3β-ol",single,29,34).
+
+atom("4α-formyl-5α-cholest-7,24-dien-3β-ol",1..28,carb). atom("4α-formyl-5α-cholest-7,24-dien-3β-ol",31,oxyg). atom("4α-formyl-5α-cholest-7,24-dien-3β-ol",34,oxyg).
+bond("4α-formyl-5α-cholest-7,24-dien-3β-ol",single,1,2). bond("4α-formyl-5α-cholest-7,24-dien-3β-ol",single,1,10). bond("4α-formyl-5α-cholest-7,24-dien-3β-ol",single,2,3).
+bond("4α-formyl-5α-cholest-7,24-dien-3β-ol",single,3,4). bond("4α-formyl-5α-cholest-7,24-dien-3β-ol",double,3,31). bond("4α-formyl-5α-cholest-7,24-dien-3β-ol",single,4,5).
+bond("4α-formyl-5α-cholest-7,24-dien-3β-ol",singleS,4,28). bond("4α-formyl-5α-cholest-7,24-dien-3β-ol",single,5,6). bond("4α-formyl-5α-cholest-7,24-dien-3β-ol",single,5,10).
+bond("4α-formyl-5α-cholest-7,24-dien-3β-ol",single,6,7). bond("4α-formyl-5α-cholest-7,24-dien-3β-ol",double,7,8). bond("4α-formyl-5α-cholest-7,24-dien-3β-ol",single,8,9).
+bond("4α-formyl-5α-cholest-7,24-dien-3β-ol",single,8,14). bond("4α-formyl-5α-cholest-7,24-dien-3β-ol",single,9,10). bond("4α-formyl-5α-cholest-7,24-dien-3β-ol",single,9,11).
+bond("4α-formyl-5α-cholest-7,24-dien-3β-ol",singleR,10,19). bond("4α-formyl-5α-cholest-7,24-dien-3β-ol",single,11,12). bond("4α-formyl-5α-cholest-7,24-dien-3β-ol",single,12,13).
+bond("4α-formyl-5α-cholest-7,24-dien-3β-ol",single,13,14). bond("4α-formyl-5α-cholest-7,24-dien-3β-ol",single,14,15). bond("4α-formyl-5α-cholest-7,24-dien-3β-ol",single,15,16).
+bond("4α-formyl-5α-cholest-7,24-dien-3β-ol",single,16,17). bond("4α-formyl-5α-cholest-7,24-dien-3β-ol",single,13,17). bond("4α-formyl-5α-cholest-7,24-dien-3β-ol",singleR,13,18).
+bond("4α-formyl-5α-cholest-7,24-dien-3β-ol",singleR,17,20). bond("4α-formyl-5α-cholest-7,24-dien-3β-ol",singleS,20,21). bond("4α-formyl-5α-cholest-7,24-dien-3β-ol",single,20,22).
+bond("4α-formyl-5α-cholest-7,24-dien-3β-ol",single,22,23). bond("4α-formyl-5α-cholest-7,24-dien-3β-ol",single,23,24). bond("4α-formyl-5α-cholest-7,24-dien-3β-ol",double,24,25).
+bond("4α-formyl-5α-cholest-7,24-dien-3β-ol",single,25,26). bond("4α-formyl-5α-cholest-7,24-dien-3β-ol",single,25,27). bond("4α-formyl-5α-cholest-7,24-dien-3β-ol",double,29,34).
+
+atom("4α-carboxy-5α-cholesta-7,24-dien-3β-ol",1..28,carb). atom("4α-carboxy-5α-cholesta-7,24-dien-3β-ol",31,oxyg). atom("4α-carboxy-5α-cholesta-7,24-dien-3β-ol",34..35,oxyg).
+bond("4α-carboxy-5α-cholesta-7,24-dien-3β-ol",single,1,2). bond("4α-carboxy-5α-cholesta-7,24-dien-3β-ol",single,1,10). bond("4α-carboxy-5α-cholesta-7,24-dien-3β-ol",single,2,3).
+bond("4α-carboxy-5α-cholesta-7,24-dien-3β-ol",single,3,4). bond("4α-carboxy-5α-cholesta-7,24-dien-3β-ol",double,3,31). bond("4α-carboxy-5α-cholesta-7,24-dien-3β-ol",single,4,5).
+bond("4α-carboxy-5α-cholesta-7,24-dien-3β-ol",singleS,4,28). bond("4α-carboxy-5α-cholesta-7,24-dien-3β-ol",single,5,6). bond("4α-carboxy-5α-cholesta-7,24-dien-3β-ol",single,5,10).
+bond("4α-carboxy-5α-cholesta-7,24-dien-3β-ol",single,6,7). bond("4α-carboxy-5α-cholesta-7,24-dien-3β-ol",double,7,8). bond("4α-carboxy-5α-cholesta-7,24-dien-3β-ol",single,8,9).
+bond("4α-carboxy-5α-cholesta-7,24-dien-3β-ol",single,8,14). bond("4α-carboxy-5α-cholesta-7,24-dien-3β-ol",single,9,10). bond("4α-carboxy-5α-cholesta-7,24-dien-3β-ol",single,9,11).
+bond("4α-carboxy-5α-cholesta-7,24-dien-3β-ol",singleR,10,19). bond("4α-carboxy-5α-cholesta-7,24-dien-3β-ol",single,11,12). bond("4α-carboxy-5α-cholesta-7,24-dien-3β-ol",single,12,13).
+bond("4α-carboxy-5α-cholesta-7,24-dien-3β-ol",single,13,14). bond("4α-carboxy-5α-cholesta-7,24-dien-3β-ol",single,14,15). bond("4α-carboxy-5α-cholesta-7,24-dien-3β-ol",single,15,16).
+bond("4α-carboxy-5α-cholesta-7,24-dien-3β-ol",single,16,17). bond("4α-carboxy-5α-cholesta-7,24-dien-3β-ol",single,13,17). bond("4α-carboxy-5α-cholesta-7,24-dien-3β-ol",singleR,13,18).
+bond("4α-carboxy-5α-cholesta-7,24-dien-3β-ol",singleR,17,20). bond("4α-carboxy-5α-cholesta-7,24-dien-3β-ol",singleS,20,21). bond("4α-carboxy-5α-cholesta-7,24-dien-3β-ol",single,20,22).
+bond("4α-carboxy-5α-cholesta-7,24-dien-3β-ol",single,22,23). bond("4α-carboxy-5α-cholesta-7,24-dien-3β-ol",single,23,24). bond("4α-carboxy-5α-cholesta-7,24-dien-3β-ol",double,24,25).
+bond("4α-carboxy-5α-cholesta-7,24-dien-3β-ol",single,25,26). bond("4α-carboxy-5α-cholesta-7,24-dien-3β-ol",single,25,27).bond("4α-carboxy-5α-cholesta-7,24-dien-3β-ol",double,29,34).
+bond("4α-carboxy-5α-cholesta-7,24-dien-3β-ol",single,29,35).
+
+atom("5α-cholesta-7,24-dien-3-one",1..27,carb). atom("5α-cholesta-7,24-dien-3-one",31,oxyg).
+bond("5α-cholesta-7,24-dien-3-one",single,1,2). bond("5α-cholesta-7,24-dien-3-one",single,1,10). bond("5α-cholesta-7,24-dien-3-one",single,2,3).
+bond("5α-cholesta-7,24-dien-3-one",single,3,4). bond("5α-cholesta-7,24-dien-3-one",double,3,31). bond("5α-cholesta-7,24-dien-3-one",single,4,5).
+bond("5α-cholesta-7,24-dien-3-one",single,5,6). bond("5α-cholesta-7,24-dien-3-one",single,5,10). bond("5α-cholesta-7,24-dien-3-one",single,6,7).
+bond("5α-cholesta-7,24-dien-3-one",double,7,8). bond("5α-cholesta-7,24-dien-3-one",single,8,9). bond("5α-cholesta-7,24-dien-3-one",single,8,14).
+bond("5α-cholesta-7,24-dien-3-one",single,9,10). bond("5α-cholesta-7,24-dien-3-one",single,9,11). bond("5α-cholesta-7,24-dien-3-one",singleR,10,19).
+bond("5α-cholesta-7,24-dien-3-one",single,11,12). bond("5α-cholesta-7,24-dien-3-one",single,12,13). bond("5α-cholesta-7,24-dien-3-one",single,13,14).
+bond("5α-cholesta-7,24-dien-3-one",single,14,15). bond("5α-cholesta-7,24-dien-3-one",single,15,16). bond("5α-cholesta-7,24-dien-3-one",single,16,17).
+bond("5α-cholesta-7,24-dien-3-one",single,13,17). bond("5α-cholesta-7,24-dien-3-one",singleR,13,18). bond("5α-cholesta-7,24-dien-3-one",singleR,17,20).
+bond("5α-cholesta-7,24-dien-3-one",singleS,20,21). bond("5α-cholesta-7,24-dien-3-one",single,20,22). bond("5α-cholesta-7,24-dien-3-one",single,22,23).
+bond("5α-cholesta-7,24-dien-3-one",single,23,24). bond("5α-cholesta-7,24-dien-3-one",double,24,25). bond("5α-cholesta-7,24-dien-3-one",single,25,26).
+bond("5α-cholesta-7,24-dien-3-one",single,25,27).
+
+atom("5α-cholesta-7,24-dienol",1..27,carb). atom("5α-cholesta-7,24-dienol",31,oxyg).
+bond("5α-cholesta-7,24-dienol",single,1,2). bond("5α-cholesta-7,24-dienol",single,1,10). bond("5α-cholesta-7,24-dienol",single,2,3).
+bond("5α-cholesta-7,24-dienol",single,3,4). bond("5α-cholesta-7,24-dienol",singleR,3,31). bond("5α-cholesta-7,24-dienol",single,4,5).
+bond("5α-cholesta-7,24-dienol",single,5,6). bond("5α-cholesta-7,24-dienol",single,5,10). bond("5α-cholesta-7,24-dienol",single,6,7).
+bond("5α-cholesta-7,24-dienol",double,7,8). bond("5α-cholesta-7,24-dienol",single,8,9). bond("5α-cholesta-7,24-dienol",single,8,14).
+bond("5α-cholesta-7,24-dienol",single,9,10). bond("5α-cholesta-7,24-dienol",single,9,11). bond("5α-cholesta-7,24-dienol",singleR,10,19).
+bond("5α-cholesta-7,24-dienol",single,11,12). bond("5α-cholesta-7,24-dienol",single,12,13). bond("5α-cholesta-7,24-dienol",single,13,14).
+bond("5α-cholesta-7,24-dienol",single,14,15). bond("5α-cholesta-7,24-dienol",single,15,16). bond("5α-cholesta-7,24-dienol",single,16,17).
+bond("5α-cholesta-7,24-dienol",single,13,17). bond("5α-cholesta-7,24-dienol",singleR,13,18). bond("5α-cholesta-7,24-dienol",singleR,17,20).
+bond("5α-cholesta-7,24-dienol",singleS,20,21). bond("5α-cholesta-7,24-dienol",single,20,22). bond("5α-cholesta-7,24-dienol",single,22,23).
+bond("5α-cholesta-7,24-dienol",single,23,24). bond("5α-cholesta-7,24-dienol",double,24,25). bond("5α-cholesta-7,24-dienol",single,25,26).
+bond("5α-cholesta-7,24-dienol",single,25,27).
+
+atom("7-dehydrodesmosterol",1..27,carb). atom("7-dehydrodesmosterol",31,oxyg).
+bond("7-dehydrodesmosterol",single,1,2). bond("7-dehydrodesmosterol",single,1,10). bond("7-dehydrodesmosterol",single,2,3).
+bond("7-dehydrodesmosterol",single,3,4). bond("7-dehydrodesmosterol",singleR,3,31). bond("7-dehydrodesmosterol",single,4,5).
+bond("7-dehydrodesmosterol",double,5,6). bond("7-dehydrodesmosterol",single,5,10). bond("7-dehydrodesmosterol",single,6,7).
+bond("7-dehydrodesmosterol",double,7,8). bond("7-dehydrodesmosterol",single,8,9). bond("7-dehydrodesmosterol",single,8,14).
+bond("7-dehydrodesmosterol",single,9,10). bond("7-dehydrodesmosterol",single,9,11). bond("7-dehydrodesmosterol",singleR,10,19).
+bond("7-dehydrodesmosterol",single,11,12). bond("7-dehydrodesmosterol",single,12,13). bond("7-dehydrodesmosterol",single,13,14).
+bond("7-dehydrodesmosterol",single,14,15). bond("7-dehydrodesmosterol",single,15,16). bond("7-dehydrodesmosterol",single,16,17).
+bond("7-dehydrodesmosterol",single,13,17). bond("7-dehydrodesmosterol",singleR,13,18). bond("7-dehydrodesmosterol",singleR,17,20).
+bond("7-dehydrodesmosterol",singleS,20,21). bond("7-dehydrodesmosterol",single,20,22). bond("7-dehydrodesmosterol",single,22,23).
+bond("7-dehydrodesmosterol",single,23,24). bond("7-dehydrodesmosterol",double,24,25). bond("7-dehydrodesmosterol",single,25,26).
+bond("7-dehydrodesmosterol",single,25,27).
+
+atom("desmosterol",1..27,carb). atom("desmosterol",31,oxyg).
+bond("desmosterol",single,1,2). bond("desmosterol",single,1,10). bond("desmosterol",single,2,3).
+bond("desmosterol",single,3,4). bond("desmosterol",singleR,3,31). bond("desmosterol",single,4,5).
+bond("desmosterol",double,5,6). bond("desmosterol",single,5,10). bond("desmosterol",single,6,7).
+bond("desmosterol",single,7,8). bond("desmosterol",single,8,9). bond("desmosterol",single,8,14).
+bond("desmosterol",single,9,10). bond("desmosterol",single,9,11). bond("desmosterol",singleR,10,19).
+bond("desmosterol",single,11,12). bond("desmosterol",single,12,13). bond("desmosterol",single,13,14).
+bond("desmosterol",single,14,15). bond("desmosterol",single,15,16). bond("desmosterol",single,16,17).
+bond("desmosterol",single,13,17). bond("desmosterol",singleR,13,18). bond("desmosterol",singleR,17,20).
+bond("desmosterol",singleS,20,21). bond("desmosterol",single,20,22). bond("desmosterol",single,22,23).
+bond("desmosterol",single,23,24). bond("desmosterol",double,24,25). bond("desmosterol",single,25,26).
+bond("desmosterol",single,25,27).
+
+atom("cholesterol",1..27,carb). atom("cholesterol",31,oxyg).
+bond("cholesterol",single,1,2). bond("cholesterol",single,1,10). bond("cholesterol",single,2,3).
+bond("cholesterol",single,3,4). bond("cholesterol",singleR,3,31). bond("cholesterol",single,4,5).
+bond("cholesterol",double,5,6). bond("cholesterol",single,5,10). bond("cholesterol",single,6,7).
+bond("cholesterol",single,7,8). bond("cholesterol",single,8,9). bond("cholesterol",single,8,14).
+bond("cholesterol",single,9,10). bond("cholesterol",single,9,11). bond("cholesterol",singleR,10,19).
+bond("cholesterol",single,11,12). bond("cholesterol",single,12,13). bond("cholesterol",single,13,14).
+bond("cholesterol",single,14,15). bond("cholesterol",single,15,16). bond("cholesterol",single,16,17).
+bond("cholesterol",single,13,17). bond("cholesterol",singleR,13,18). bond("cholesterol",singleR,17,20).
+bond("cholesterol",singleS,20,21). bond("cholesterol",single,20,22). bond("cholesterol",single,22,23).
+bond("cholesterol",single,23,24). bond("cholesterol",single,24,25). bond("cholesterol",single,25,26).
+bond("cholesterol",single,25,27).
+
+
+%* Known reactions
+%%%%%%%%%%%%%%%%%%%
+reaction(Reaction type (name), Compound 1 [, Active site atom number], [Compound 2 , Active site atom number], Resulting compound)
+*%
+
+
+% Reactions from PWY-8191: cholesterol biosynthesis (algae, late side-chain reductase) 
+
+reaction(rxn_21826, "cycloartenol","(3β,9β)-4α-demethyl-4α-methylhydroxy-9,19-cyclolanost-24-en-3-ol").
+reaction(rxn_21827, "(3β,9β)-4α-demethyl-4α-methylhydroxy-9,19-cyclolanost-24-en-3-ol", "(3β,9β)-4α-demethyl-4α-formyl-9,19-cyclolanost-24-en-3-ol").
+reaction(rxn_21828, "(3β,9β)-4α-demethyl-4α-formyl-9,19-cyclolanost-24-en-3-ol", "(3β,9β)-4α-demethyl-4α-carboxy-9,19-cyclolanost-24-en-3-ol").
+reaction(rxn_21830, "(3β,9β)-4α-demethyl-4α-carboxy-9,19-cyclolanost-24-en-3-ol", "31-norcycloartenone").
+reaction(rxn_21831, "31-norcycloartenone", "31-norcycloartenol").
+reaction(rxn_11876, "31-norcycloartenol", "4α,14α-dimethyl-5α-cholesta-8,24-dien-3β-ol").
+reaction(rxn_21165, "4α,14α-dimethyl-5α-cholesta-8,24-dien-3β-ol", "4α-hydroxymethyl-14α-methyl-5α-cholesta-8,24-dien-3β-ol").
+reaction(rxn_21166, "4α-hydroxymethyl-14α-methyl-5α-cholesta-8,24-dien-3β-ol", "4α-formyl-14α-methyl-5α-cholesta-8,24-dien-3β-ol").
+reaction(rxn_21167, "4α-formyl-14α-methyl-5α-cholesta-8,24-dien-3β-ol", "4α-methyl-5α-cholesta-8,14,24-trien-3β-ol").
+reaction(rxn_11878, "4α-methyl-5α-cholesta-8,14,24-trien-3β-ol", "4α-methyl-5α-cholesta-8,24-dien-3β-ol").
+reaction(rxn_11884, "4α-methyl-5α-cholesta-8,24-dien-3β-ol", "4α-methyl-5α-cholesta-7,24-dien-3β-ol").
+reaction(rxn_21833, "4α-methyl-5α-cholesta-7,24-dien-3β-ol", "4α-methylhydroxy-5α-cholest-7,24-dien-3β-ol").
+reaction(rxn_21834, "4α-methylhydroxy-5α-cholest-7,24-dien-3β-ol", "4α-formyl-5α-cholest-7,24-dien-3β-ol").
+reaction(rxn_21835, "4α-formyl-5α-cholest-7,24-dien-3β-ol", "4α-carboxy-5α-cholesta-7,24-dien-3β-ol").
+reaction(rxn_11959, "4α-carboxy-5α-cholesta-7,24-dien-3β-ol", "5α-cholesta-7,24-dien-3-one").
+reaction(rxn_21837, "5α-cholesta-7,24-dien-3-one", "5α-cholesta-7,24-dienol").
+reaction(rxn_11887, "5α-cholesta-7,24-dienol", "7-dehydrodesmosterol").
+reaction(rxn66_27, "7-dehydrodesmosterol", "desmosterol").
+% PWY66-4 and PWY-8191
+reaction(rxn66_28, "desmosterol", "cholesterol").
+
+
+% PWY-2541
+reaction(rxn_4021,"cycloartenol","24-methylenecycloartanol").
+reaction(rxn_4021,"cycloartenol","24-methylenecycloartanol").
+reaction(rxn_11926,"24-methylenecycloartanol","4α-hydroxymethyl,4β,14α-dimethyl-9β,19-cyclo-5α-ergost-24(241)-en-3β-ol").
+reaction(rxn_11925,"4α-hydroxymethyl,4β,14α-dimethyl-9β,19-cyclo-5α-ergost-24(241)-en-3β-ol","4α-formyl,4β,14α-dimethyl-9β,19-cyclo-5α-ergost-24(241)-en-3β-ol").
+reaction(rxn_11927,"4α-formyl,4β,14α-dimethyl-9β,19-cyclo-5α-ergost-24(241)-en-3β-ol","4α-carboxy-4β,14α-dimethyl-9β,19-cyclo-5α-ergost-24(241)-en-3β-ol").
+reaction(rxn_11928,"4α-carboxy-4β,14α-dimethyl-9β,19-cyclo-5α-ergost-24(241)-en-3β-ol","cycloeucalenone").
+reaction(rxn_11929,"cycloeucalenone","cycloeucalenol").
+reaction(cycloeucalenol_cycloisomerase_rxn,"cycloeucalenol","obtusifoliol").
+reaction(obtusifoliol_demethylase,"obtusifoliol","4α-methyl-5α-ergosta-8,14,24(28)-trien-3β-ol").
+reaction(rxn_4144,"4α-methyl-5α-ergosta-8,14,24(28)-trien-3β-ol","4α-methyl-5α-ergosta-8,24-dien-3β-ol").
+reaction(rxn_4161,"4α-methyl-5α-ergosta-8,24-dien-3β-ol","24-methylenelophenol").
+reaction(c24_methyltransferase,"24-methylenelophenol","24-ethylidenelophenol").
+reaction(rxn_11935,"24-ethylidenelophenol","4α-hydroxymethyl-stigmasta-7,24(241)-dien-3β-ol").
+reaction(rxn_11936,"4α-hydroxymethyl-stigmasta-7,24(241)-dien-3β-ol","4α-formyl-stigmasta-7,24(241)-dien-3β-ol").
+reaction(rxn_11937,"4α-formyl-stigmasta-7,24(241)-dien-3β-ol","4α-carboxy-stigmasta-7,24(241)-dien-3β-ol").
+reaction(rxn_11938,"4α-carboxy-stigmasta-7,24(241)-dien-3β-ol","avenastenone").
+reaction(rxn_11939,"avenastenone","avenasterol").
+reaction(rxn_4209,"avenasterol","5-dehydroavenasterol").
+reaction(rxn_4210,"5-dehydroavenasterol","fucosterol").
+reaction(rxn_11930,"24-methylenelophenol","4α-hydroxymethyl-ergosta-7,24(241)-dien-3β-ol").
+reaction(rxn_11931,"4α-hydroxymethyl-ergosta-7,24(241)-dien-3β-ol","4α-formyl-ergosta-7,24(241)-dien-3β-ol").
+reaction(rxn_11932,"4α-formyl-ergosta-7,24(241)-dien-3β-ol","4α-carboxy-ergosta-7,24(241)-dien-3β-ol").
+reaction(rxn_11933,"4α-carboxy-ergosta-7,24(241)-dien-3β-ol","episterone").
+reaction(rxn_11934,"episterone","episterol").
+reaction(rxn3o_218,"episterol","ergosta-5,7,24(28)-trien-3β-ol").
+reaction(rxn_707,"ergosta-5,7,24(28)-trien-3β-ol","24-methylenecholesterol").
+reaction(rxn_4222,"24-methylenecholesterol","24-methyldesmosterol").
+reaction(rxn_708,"24-methyldesmosterol","campesterol").
+reaction(rxn_2_1_1_143,"24-methylenelophenol","24-ethylidenelophenol").
+reaction(rxn_20131,"24-methylenecholesterol","campesterol").
+reaction(c22_desaturation,"campesterol","brassicasterol").
+
+
+
+% Molecules absent in the organism.
+
+absentmolecules("ergosterol").
+absentmolecules("zymosterol").
+absentmolecules("lanosterol").
+absentmolecules("lathosterol").
+absentmolecules("sitosterol").
+
+
+% Source molecule for inference.
+
+source("cycloartenol").
+
+
+% Initiation of incremental grounding.
+init(pathway("cycloartenol","cholesterol")).
+goal(pathway("cycloartenol","stigmasterol")).
+goal(pathway("cycloartenol","fucosterol")).
+
+
+%* Expected inferred reactions: 
+
+reaction(c28_methylation, "brassicasterol", "stigmasterol"). 
+*%

--- a/pathmodel/data/brown_sterols_pwy.lp
+++ b/pathmodel/data/brown_sterols_pwy.lp
@@ -660,6 +660,21 @@ bond("5α-cholesta-7,24-dienol",singleS,20,21). bond("5α-cholesta-7,24-dienol",
 bond("5α-cholesta-7,24-dienol",single,23,24). bond("5α-cholesta-7,24-dienol",double,24,25). bond("5α-cholesta-7,24-dienol",single,25,26).
 bond("5α-cholesta-7,24-dienol",single,25,27).
 
+atom("24-methyldesmosterol",1..24,carb). atom("24-methyldesmosterol",241,carb). atom("24-methyldesmosterol",25..27,carb).
+atom("24-methyldesmosterol",31,oxyg).
+bond("24-methyldesmosterol",single,1,2). bond("24-methyldesmosterol",single,1,10). bond("24-methyldesmosterol",single,2,3).
+bond("24-methyldesmosterol",single,3,4). bond("24-methyldesmosterol",singleR,3,31). bond("24-methyldesmosterol",single,4,5).
+bond("24-methyldesmosterol",double,5,6). bond("24-methyldesmosterol",single,5,10). bond("24-methyldesmosterol",single,6,7).
+bond("24-methyldesmosterol",single,7,8). bond("24-methyldesmosterol",single,8,9). bond("24-methyldesmosterol",single,8,14).
+bond("24-methyldesmosterol",single,9,10). bond("24-methyldesmosterol",single,9,11). bond("24-methyldesmosterol",singleR,10,19).
+bond("24-methyldesmosterol",single,11,12). bond("24-methyldesmosterol",single,12,13). bond("24-methyldesmosterol",single,13,14).
+bond("24-methyldesmosterol",single,14,15). bond("24-methyldesmosterol",single,15,16). bond("24-methyldesmosterol",single,16,17).
+bond("24-methyldesmosterol",single,13,17). bond("24-methyldesmosterol",singleR,13,18). bond("24-methyldesmosterol",singleR,17,20).
+bond("24-methyldesmosterol",singleS,20,21). bond("24-methyldesmosterol",single,20,22). bond("24-methyldesmosterol",single,22,23).
+bond("24-methyldesmosterol",single,23,24). bond("24-methyldesmosterol",singleR,24,241). bond("24-methyldesmosterol",double,24,25).
+bond("24-methyldesmosterol",single,25,26). bond("24-methyldesmosterol",single,25,27).
+
+
 atom("7-dehydrodesmosterol",1..27,carb). atom("7-dehydrodesmosterol",31,oxyg).
 bond("7-dehydrodesmosterol",single,1,2). bond("7-dehydrodesmosterol",single,1,10). bond("7-dehydrodesmosterol",single,2,3).
 bond("7-dehydrodesmosterol",single,3,4). bond("7-dehydrodesmosterol",singleR,3,31). bond("7-dehydrodesmosterol",single,4,5).

--- a/pathmodel/data/brown_sterols_pwy.lp
+++ b/pathmodel/data/brown_sterols_pwy.lp
@@ -235,6 +235,21 @@ bond("24-methylenelophenol",singleR,17,20). bond("24-methylenelophenol",singleS,
 bond("24-methylenelophenol",single,22,23). bond("24-methylenelophenol",single,23,24). bond("24-methylenelophenol",double,24,241).
 bond("24-methylenelophenol",single,24,25). bond("24-methylenelophenol",single,25,26). bond("24-methylenelophenol",single,25,27).
 
+atom("24-ethylenelophenol",1..24,carb). atom("24-ethylenelophenol",241,carb).  atom("24-ethylenelophenol",242,carb).
+atom("24-ethylenelophenol",25..28,carb). atom("24-ethylenelophenol",31,oxyg).
+bond("24-ethylenelophenol",single,1,2). bond("24-ethylenelophenol",single,1,10). bond("24-ethylenelophenol",single,2,3).
+bond("24-ethylenelophenol",single,3,4). bond("24-ethylenelophenol",singleR,3,31). bond("24-ethylenelophenol",single,4,5).
+bond("24-ethylenelophenol",singleS,4,28). bond("24-ethylenelophenol",single,5,6). bond("24-ethylenelophenol",single,5,10).
+bond("24-ethylenelophenol",single,6,7). bond("24-ethylenelophenol",double,7,8). bond("24-ethylenelophenol",single,8,9).
+bond("24-ethylenelophenol",single,8,14). bond("24-ethylenelophenol",single,9,10). bond("24-ethylenelophenol",single,9,11).
+bond("24-ethylenelophenol",singleR,10,19). bond("24-ethylenelophenol",single,11,12). bond("24-ethylenelophenol",single,12,13).
+bond("24-ethylenelophenol",single,13,14). bond("24-ethylenelophenol",single,14,15). bond("24-ethylenelophenol",single,15,16).
+bond("24-ethylenelophenol",single,16,17). bond("24-ethylenelophenol",single,13,17). bond("24-ethylenelophenol",singleR,13,18).
+bond("24-ethylenelophenol",singleR,17,20). bond("24-ethylenelophenol",singleS,20,21). bond("24-ethylenelophenol",single,20,22).
+bond("24-ethylenelophenol",single,22,23). bond("24-ethylenelophenol",single,23,24). bond("24-ethylenelophenol",double,24,241).
+bond("24-ethylenelophenol",single,24,25). bond("24-ethylenelophenol",single,241,242). bond("24-ethylenelophenol",single,25,26).
+bond("24-ethylenelophenol",single,25,27).
+
 % 24-ethylidenelophenol branch
 
 atom("24-ethylidenelophenol",1..24,carb). atom("24-ethylidenelophenol",241,carb). atom("24-ethylidenelophenol",242,carb).
@@ -699,6 +714,25 @@ bond("cholesterol",singleS,20,21). bond("cholesterol",single,20,22). bond("chole
 bond("cholesterol",single,23,24). bond("cholesterol",single,24,25). bond("cholesterol",single,25,26).
 bond("cholesterol",single,25,27).
 
+%*
+Shared domain
+Definition of sterane
+Based on the wikipedia structure: https://fr.wikipedia.org/wiki/St%C3%A9rane#/media/File:Steran_num_ABCD.svg
+*%
+
+atomDomain(sterane,1,carb). atomDomain(sterane,2,carb). atomDomain(sterane,3,carb).
+atomDomain(sterane,4,carb). atomDomain(sterane,5,carb). atomDomain(sterane,6,carb).
+atomDomain(sterane,7,carb). atomDomain(sterane,8,carb). atomDomain(sterane,9,carb).
+atomDomain(sterane,10,carb). atomDomain(sterane,11,carb). atomDomain(sterane,12,carb).
+atomDomain(sterane,13,carb). atomDomain(sterane,14,carb). atomDomain(sterane,15,carb).
+atomDomain(sterane,16,carb). atomDomain(sterane,17,carb).
+bondDomain(sterane,variable,1,2). bondDomain(sterane,variable,1,10). bondDomain(sterane,variable,2,3).
+bondDomain(sterane,variable,3,4). bondDomain(sterane,variable,4,5). bondDomain(sterane,variable,5,6).
+bondDomain(sterane,variable,5,10). bondDomain(sterane,variable,6,7). bondDomain(sterane,variable,7,8).
+bondDomain(sterane,variable,8,9). bondDomain(sterane,variable,8,14). bondDomain(sterane,variable,9,10).
+bondDomain(sterane,variable,9,11). bondDomain(sterane,variable,11,12). bondDomain(sterane,variable,12,13).
+bondDomain(sterane,variable,13,14). bondDomain(sterane,variable,13,17). bondDomain(sterane,variable,14,15).
+bondDomain(sterane,variable,15,16). bondDomain(sterane,variable,16,17).
 
 %* Known reactions
 %%%%%%%%%%%%%%%%%%%
@@ -732,7 +766,6 @@ reaction(rxn66_28, "desmosterol", "cholesterol").
 
 % PWY-2541
 reaction(rxn_4021,"cycloartenol","24-methylenecycloartanol").
-reaction(rxn_4021,"cycloartenol","24-methylenecycloartanol").
 reaction(rxn_11926,"24-methylenecycloartanol","4α-hydroxymethyl,4β,14α-dimethyl-9β,19-cyclo-5α-ergost-24(241)-en-3β-ol").
 reaction(rxn_11925,"4α-hydroxymethyl,4β,14α-dimethyl-9β,19-cyclo-5α-ergost-24(241)-en-3β-ol","4α-formyl,4β,14α-dimethyl-9β,19-cyclo-5α-ergost-24(241)-en-3β-ol").
 reaction(rxn_11927,"4α-formyl,4β,14α-dimethyl-9β,19-cyclo-5α-ergost-24(241)-en-3β-ol","4α-carboxy-4β,14α-dimethyl-9β,19-cyclo-5α-ergost-24(241)-en-3β-ol").
@@ -748,6 +781,8 @@ reaction(rxn_11936,"4α-hydroxymethyl-stigmasta-7,24(241)-dien-3β-ol","4α-form
 reaction(rxn_11937,"4α-formyl-stigmasta-7,24(241)-dien-3β-ol","4α-carboxy-stigmasta-7,24(241)-dien-3β-ol").
 reaction(rxn_11938,"4α-carboxy-stigmasta-7,24(241)-dien-3β-ol","avenastenone").
 reaction(rxn_11939,"avenastenone","avenasterol").
+reaction(c28_methylation,"24-methylenelophenol","24-ethylenelophenol").
+reaction(c4_demethylation,"24-ethylenelophenol","avenasterol").
 reaction(rxn_4209,"avenasterol","5-dehydroavenasterol").
 reaction(rxn_4210,"5-dehydroavenasterol","fucosterol").
 reaction(rxn_11930,"24-methylenelophenol","4α-hydroxymethyl-ergosta-7,24(241)-dien-3β-ol").
@@ -783,7 +818,6 @@ source("cycloartenol").
 init(pathway("cycloartenol","cholesterol")).
 goal(pathway("cycloartenol","stigmasterol")).
 goal(pathway("cycloartenol","fucosterol")).
-
 
 %* Expected inferred reactions: 
 

--- a/pathmodel/data/mozukulins_pwy.lp
+++ b/pathmodel/data/mozukulins_pwy.lp
@@ -156,18 +156,20 @@ reaction(rxn_21830, "(3β,9β)-4α-demethyl-4α-carboxy-9,19-cyclolanost-24-en-3
 
 % Information necessary to infer new Δ1-2 reduction
 % PWY-6944: androstenedione degradation I (aerobic)
-reaction(rxn_12714,"androst-4-ene-3,17-dione","androsta-1,4-diene-3,17-dione). 
+reaction(rxn_12714,"androst-4-ene-3,17-dione","androsta-1,4-diene-3,17-dione").
 % corresponding metacyc general reactions (EC 1.3.99.4)
-reaction(3-OXOSTEROID-1-DEHYDROGENASE-RXN,"a 3-oxosteroid", "a 3-oxo-Δ1-steroid").
+reaction(rxn_3_OXOSTEROID_1_DEHYDROGENASE_RXN,"a 3-oxosteroid", "a 3-oxo-Δ1-steroid").
 
 % Information necessary to infer new 23 hydroxylation
 reaction(rxn_11530, "(22α)-hydroxy-campest-4-en-3-one", "(22R,23R)-22,23-dihydroxy-campest-4-en-3-one").
 
-% Information necessary to infer new 23 dehydrogenation
+%*
+Information necessary to infer new 23 dehydrogenation
 Here we have to define the general concept of steroid dehydrogenation based on the numerous occurrences on various positions: 3, 7, 11, 12, 17, 20 
 https://metacyc.org/META/substring-search?type=NIL&object=hydroxysteroid+dehydrogenase&quickSearch=Quick+Search#ENZYME
 The candidate enzyme could belong either to the short-chain dehydrogenase family (SDR) or to the aldo-ketoreductases. 
 Alternatively, the reaction could also be performed by a CYP enzyme in a CYP85 or CYP90A-like manner.
+*%
 
 % PWY66-4 and PWY-8191
 reaction(rxn66_28, "desmosterol", "cholesterol").

--- a/pathmodel/data/mozukulins_pwy.lp
+++ b/pathmodel/data/mozukulins_pwy.lp
@@ -283,6 +283,28 @@ bond("cholesterol",singleS,20,21). bond("cholesterol",single,20,22). bond("chole
 bond("cholesterol",single,23,24). bond("cholesterol",single,24,25). bond("cholesterol",single,25,26).
 bond("cholesterol",single,25,27).
 
+% Class compounds for rxn_3_OXOSTEROID_1_DEHYDROGENASE_RXN
+
+atom("a 3-oxosteroid",1..19,carb). atom("a 3-oxosteroid",20,variable). atom("a 3-oxosteroid",31,oxyg).
+bond("a 3-oxosteroid",single,1,2). bond("a 3-oxosteroid",single,1,10). bond("a 3-oxosteroid",single,2,3).
+bond("a 3-oxosteroid",single,3,4). bond("a 3-oxosteroid",double,3,31). bond("a 3-oxosteroid",single,4,5).
+bond("a 3-oxosteroid",single,5,6). bond("a 3-oxosteroid",single,5,10). bond("a 3-oxosteroid",single,6,7).
+bond("a 3-oxosteroid",single,7,8). bond("a 3-oxosteroid",single,8,9). bond("a 3-oxosteroid",single,8,14).
+bond("a 3-oxosteroid",single,9,10). bond("a 3-oxosteroid",single,9,11). bond("a 3-oxosteroid",single,10,19).
+bond("a 3-oxosteroid",single,11,12). bond("a 3-oxosteroid",single,12,13). bond("a 3-oxosteroid",single,13,14).
+bond("a 3-oxosteroid",single,14,15). bond("a 3-oxosteroid",single,15,16). bond("a 3-oxosteroid",single,16,17).
+bond("a 3-oxosteroid",single,13,17). bond("a 3-oxosteroid",single,13,18). bond("a 3-oxosteroid",single,17,20).
+
+atom("a 3-oxo-Δ1-steroid",1..19,carb). atom("a 3-oxo-Δ1-steroid",20,variable). atom("a 3-oxo-Δ1-steroid",31,oxyg).
+bond("a 3-oxo-Δ1-steroid",double,1,2). bond("a 3-oxo-Δ1-steroid",single,1,10). bond("a 3-oxo-Δ1-steroid",single,2,3).
+bond("a 3-oxo-Δ1-steroid",single,3,4). bond("a 3-oxo-Δ1-steroid",double,3,31). bond("a 3-oxo-Δ1-steroid",single,4,5).
+bond("a 3-oxo-Δ1-steroid",single,5,6). bond("a 3-oxo-Δ1-steroid",single,5,10). bond("a 3-oxo-Δ1-steroid",single,6,7).
+bond("a 3-oxo-Δ1-steroid",single,7,8). bond("a 3-oxo-Δ1-steroid",single,8,9). bond("a 3-oxo-Δ1-steroid",single,8,14).
+bond("a 3-oxo-Δ1-steroid",single,9,10). bond("a 3-oxo-Δ1-steroid",single,9,11). bond("a 3-oxo-Δ1-steroid",single,10,19).
+bond("a 3-oxo-Δ1-steroid",single,11,12). bond("a 3-oxo-Δ1-steroid",single,12,13). bond("a 3-oxo-Δ1-steroid",single,13,14).
+bond("a 3-oxo-Δ1-steroid",single,14,15). bond("a 3-oxo-Δ1-steroid",single,15,16). bond("a 3-oxo-Δ1-steroid",single,16,17).
+bond("a 3-oxo-Δ1-steroid",single,13,17). bond("a 3-oxo-Δ1-steroid",single,13,18). bond("a 3-oxo-Δ1-steroid",single,17,20).
+
 % PWY-6944: androstenedione degradation I (aerobic)
 
 atom("androst-4-ene-3,17-dione",1..19,carb). atom("androst-4-ene-3,17-dione",20,oxyg). atom("androst-4-ene-3,17-dione",31,oxyg).
@@ -309,8 +331,8 @@ bond("androsta-1,4-diene-3,17-dione",single,15,16). bond("androsta-1,4-diene-3,1
 atom("(22α)-hydroxy-campest-4-en-3-one",1..27,carb).  atom("(22α)-hydroxy-campest-4-en-3-one",30,carb). atom("(22α)-hydroxy-campest-4-en-3-one",31,oxyg).
 atom("(22α)-hydroxy-campest-4-en-3-one",34,oxyg). atom("(22α)-hydroxy-campest-4-en-3-one",35,carb).
 bond("(22α)-hydroxy-campest-4-en-3-one",single,1,2). bond("(22α)-hydroxy-campest-4-en-3-one",single,1,10). bond("(22α)-hydroxy-campest-4-en-3-one",single,2,3).
-bond("(22α)-hydroxy-campest-4-en-3-one",single,3,4). bond("(22α)-hydroxy-campest-4-en-3-one",double,3,31). bond("(22α)-hydroxy-campest-4-en-3-one",single,4,5).
-bond("(22α)-hydroxy-campest-4-en-3-one",double,5,6). bond("(22α)-hydroxy-campest-4-en-3-one",single,5,10). bond("(22α)-hydroxy-campest-4-en-3-one",single,6,7).
+bond("(22α)-hydroxy-campest-4-en-3-one",single,3,4). bond("(22α)-hydroxy-campest-4-en-3-one",double,3,31). bond("(22α)-hydroxy-campest-4-en-3-one",double,4,5).
+bond("(22α)-hydroxy-campest-4-en-3-one",single,5,6). bond("(22α)-hydroxy-campest-4-en-3-one",single,5,10). bond("(22α)-hydroxy-campest-4-en-3-one",single,6,7).
 bond("(22α)-hydroxy-campest-4-en-3-one",single,7,8). bond("(22α)-hydroxy-campest-4-en-3-one",single,8,9). bond("(22α)-hydroxy-campest-4-en-3-one",single,8,14).
 bond("(22α)-hydroxy-campest-4-en-3-one",single,9,10). bond("(22α)-hydroxy-campest-4-en-3-one",single,9,11). bond("(22α)-hydroxy-campest-4-en-3-one",singleR,10,19).
 bond("(22α)-hydroxy-campest-4-en-3-one",single,11,12). bond("(22α)-hydroxy-campest-4-en-3-one",single,12,13). bond("(22α)-hydroxy-campest-4-en-3-one",single,13,14).
@@ -324,8 +346,8 @@ bond("(22α)-hydroxy-campest-4-en-3-one",single,25,27).
 atom("(22R,23R)-22,23-dihydroxy-campest-4-en-3-one",1..27,carb).  atom("(22R,23R)-22,23-dihydroxy-campest-4-en-3-one",30,carb). atom("(22R,23R)-22,23-dihydroxy-campest-4-en-3-one",31,oxyg).
 atom("(22R,23R)-22,23-dihydroxy-campest-4-en-3-one",32,oxyg). atom("(22R,23R)-22,23-dihydroxy-campest-4-en-3-one",34,oxyg). atom("(22R,23R)-22,23-dihydroxy-campest-4-en-3-one",35,carb).
 bond("(22R,23R)-22,23-dihydroxy-campest-4-en-3-one",single,1,2). bond("(22R,23R)-22,23-dihydroxy-campest-4-en-3-one",single,1,10). bond("(22R,23R)-22,23-dihydroxy-campest-4-en-3-one",single,2,3).
-bond("(22R,23R)-22,23-dihydroxy-campest-4-en-3-one",single,3,4). bond("(22R,23R)-22,23-dihydroxy-campest-4-en-3-one",double,3,31). bond("(22R,23R)-22,23-dihydroxy-campest-4-en-3-one",single,4,5).
-bond("(22R,23R)-22,23-dihydroxy-campest-4-en-3-one",double,5,6). bond("(22R,23R)-22,23-dihydroxy-campest-4-en-3-one",single,5,10). bond("(22R,23R)-22,23-dihydroxy-campest-4-en-3-one",single,6,7).
+bond("(22R,23R)-22,23-dihydroxy-campest-4-en-3-one",single,3,4). bond("(22R,23R)-22,23-dihydroxy-campest-4-en-3-one",double,3,31). bond("(22R,23R)-22,23-dihydroxy-campest-4-en-3-one",double,4,5).
+bond("(22R,23R)-22,23-dihydroxy-campest-4-en-3-one",single,5,6). bond("(22R,23R)-22,23-dihydroxy-campest-4-en-3-one",single,5,10). bond("(22R,23R)-22,23-dihydroxy-campest-4-en-3-one",single,6,7).
 bond("(22R,23R)-22,23-dihydroxy-campest-4-en-3-one",single,7,8). bond("(22R,23R)-22,23-dihydroxy-campest-4-en-3-one",single,8,9). bond("(22R,23R)-22,23-dihydroxy-campest-4-en-3-one",single,8,14).
 bond("(22R,23R)-22,23-dihydroxy-campest-4-en-3-one",single,9,10). bond("(22R,23R)-22,23-dihydroxy-campest-4-en-3-one",single,9,11). bond("(22R,23R)-22,23-dihydroxy-campest-4-en-3-one",singleR,10,19).
 bond("(22R,23R)-22,23-dihydroxy-campest-4-en-3-one",single,11,12). bond("(22R,23R)-22,23-dihydroxy-campest-4-en-3-one",single,12,13). bond("(22R,23R)-22,23-dihydroxy-campest-4-en-3-one",single,13,14).
@@ -451,9 +473,9 @@ reaction(rxn66_28, "desmosterol", "cholesterol").
 
 % Information necessary to infer new Δ1-2 reduction
 % PWY-6944: androstenedione degradation I (aerobic)
-reaction(rxn_12714,"androst-4-ene-3,17-dione","androsta-1,4-diene-3,17-dione").
+reaction(rxn_12714, "androst-4-ene-3,17-dione", "androsta-1,4-diene-3,17-dione").
 % corresponding metacyc general reactions (EC 1.3.99.4)
-reaction(rxn_3_OXOSTEROID_1_DEHYDROGENASE_RXN,"a 3-oxosteroid", "a 3-oxo-Δ1-steroid").
+reaction(rxn_3_OXOSTEROID_1_DEHYDROGENASE_RXN, "a 3-oxosteroid", "a 3-oxo-Δ1-steroid").
 
 % Information necessary to infer new 23 hydroxylation
 reaction(rxn_11530, "(22α)-hydroxy-campest-4-en-3-one", "(22R,23R)-22,23-dihydroxy-campest-4-en-3-one").

--- a/pathmodel/data/mozukulins_pwy.lp
+++ b/pathmodel/data/mozukulins_pwy.lp
@@ -28,13 +28,38 @@ bond("cycloartenol",single,25,26). bond("cycloartenol",single,25,27).
 
 % Sterols from PWY-8191
 
+atom("(3β,9β)-4α-demethyl-4α-methylhydroxy-9,19-cyclolanost-24-en-3-ol",1..30,carb). atom("(3β,9β)-4α-demethyl-4α-methylhydroxy-9,19-cyclolanost-24-en-3-ol",31,oxyg). atom("(3β,9β)-4α-demethyl-4α-methylhydroxy-9,19-cyclolanost-24-en-3-ol",33,oxyg).
+bond("(3β,9β)-4α-demethyl-4α-methylhydroxy-9,19-cyclolanost-24-en-3-ol",single,1,2). bond("(3β,9β)-4α-demethyl-4α-methylhydroxy-9,19-cyclolanost-24-en-3-ol",single,1,10). bond("(3β,9β)-4α-demethyl-4α-methylhydroxy-9,19-cyclolanost-24-en-3-ol",single,2,3).
+bond("(3β,9β)-4α-demethyl-4α-methylhydroxy-9,19-cyclolanost-24-en-3-ol",single,3,4). bond("(3β,9β)-4α-demethyl-4α-methylhydroxy-9,19-cyclolanost-24-en-3-ol",singleR,3,31). bond("(3β,9β)-4α-demethyl-4α-methylhydroxy-9,19-cyclolanost-24-en-3-ol",single,4,5).
+bond("(3β,9β)-4α-demethyl-4α-methylhydroxy-9,19-cyclolanost-24-en-3-ol",singleR,4,29). bond("(3β,9β)-4α-demethyl-4α-methylhydroxy-9,19-cyclolanost-24-en-3-ol",singleS,4,28). bond("(3β,9β)-4α-demethyl-4α-methylhydroxy-9,19-cyclolanost-24-en-3-ol",single,5,6).
+bond("(3β,9β)-4α-demethyl-4α-methylhydroxy-9,19-cyclolanost-24-en-3-ol",single,5,10). bond("(3β,9β)-4α-demethyl-4α-methylhydroxy-9,19-cyclolanost-24-en-3-ol",single,6,7). bond("(3β,9β)-4α-demethyl-4α-methylhydroxy-9,19-cyclolanost-24-en-3-ol",single,7,8).
+bond("(3β,9β)-4α-demethyl-4α-methylhydroxy-9,19-cyclolanost-24-en-3-ol",single,8,9). bond("(3β,9β)-4α-demethyl-4α-methylhydroxy-9,19-cyclolanost-24-en-3-ol",single,8,14). bond("(3β,9β)-4α-demethyl-4α-methylhydroxy-9,19-cyclolanost-24-en-3-ol",single,9,10).
+bond("(3β,9β)-4α-demethyl-4α-methylhydroxy-9,19-cyclolanost-24-en-3-ol",single,9,11).bond("(3β,9β)-4α-demethyl-4α-methylhydroxy-9,19-cyclolanost-24-en-3-ol",singleR,9,19). bond("(3β,9β)-4α-demethyl-4α-methylhydroxy-9,19-cyclolanost-24-en-3-ol",singleR,10,19).
+bond("(3β,9β)-4α-demethyl-4α-methylhydroxy-9,19-cyclolanost-24-en-3-ol",single,11,12). bond("(3β,9β)-4α-demethyl-4α-methylhydroxy-9,19-cyclolanost-24-en-3-ol",single,12,13). bond("(3β,9β)-4α-demethyl-4α-methylhydroxy-9,19-cyclolanost-24-en-3-ol",single,13,14).
+bond("(3β,9β)-4α-demethyl-4α-methylhydroxy-9,19-cyclolanost-24-en-3-ol",single,14,15). bond("(3β,9β)-4α-demethyl-4α-methylhydroxy-9,19-cyclolanost-24-en-3-ol",singleS,14,30). bond("(3β,9β)-4α-demethyl-4α-methylhydroxy-9,19-cyclolanost-24-en-3-ol",single,15,16).
+bond("(3β,9β)-4α-demethyl-4α-methylhydroxy-9,19-cyclolanost-24-en-3-ol",single,16,17). bond("(3β,9β)-4α-demethyl-4α-methylhydroxy-9,19-cyclolanost-24-en-3-ol",single,13,17). bond("(3β,9β)-4α-demethyl-4α-methylhydroxy-9,19-cyclolanost-24-en-3-ol",singleR,13,18).
+bond("(3β,9β)-4α-demethyl-4α-methylhydroxy-9,19-cyclolanost-24-en-3-ol",singleR,17,20). bond("(3β,9β)-4α-demethyl-4α-methylhydroxy-9,19-cyclolanost-24-en-3-ol",singleS,20,21). bond("(3β,9β)-4α-demethyl-4α-methylhydroxy-9,19-cyclolanost-24-en-3-ol",single,20,22).
+bond("(3β,9β)-4α-demethyl-4α-methylhydroxy-9,19-cyclolanost-24-en-3-ol",single,22,23). bond("(3β,9β)-4α-demethyl-4α-methylhydroxy-9,19-cyclolanost-24-en-3-ol",single,23,24). bond("(3β,9β)-4α-demethyl-4α-methylhydroxy-9,19-cyclolanost-24-en-3-ol",double,24,25).
+bond("(3β,9β)-4α-demethyl-4α-methylhydroxy-9,19-cyclolanost-24-en-3-ol",single,25,26). bond("(3β,9β)-4α-demethyl-4α-methylhydroxy-9,19-cyclolanost-24-en-3-ol",single,25,27). bond("(3β,9β)-4α-demethyl-4α-methylhydroxy-9,19-cyclolanost-24-en-3-ol",single,29,33).
+
+atom("(3β,9β)-4α-demethyl-4α-formyl-9,19-cyclolanost-24-en-3-ol",1..30,carb). atom("(3β,9β)-4α-demethyl-4α-formyl-9,19-cyclolanost-24-en-3-ol",31,oxyg). atom("(3β,9β)-4α-demethyl-4α-formyl-9,19-cyclolanost-24-en-3-ol",33,oxyg).
+bond("(3β,9β)-4α-demethyl-4α-formyl-9,19-cyclolanost-24-en-3-ol",single,1,2). bond("(3β,9β)-4α-demethyl-4α-formyl-9,19-cyclolanost-24-en-3-ol",single,1,10). bond("(3β,9β)-4α-demethyl-4α-formyl-9,19-cyclolanost-24-en-3-ol",single,2,3).
+bond("(3β,9β)-4α-demethyl-4α-formyl-9,19-cyclolanost-24-en-3-ol",single,3,4). bond("(3β,9β)-4α-demethyl-4α-formyl-9,19-cyclolanost-24-en-3-ol",singleR,3,31). bond("(3β,9β)-4α-demethyl-4α-formyl-9,19-cyclolanost-24-en-3-ol",single,4,5).
+bond("(3β,9β)-4α-demethyl-4α-formyl-9,19-cyclolanost-24-en-3-ol",singleR,4,29). bond("(3β,9β)-4α-demethyl-4α-formyl-9,19-cyclolanost-24-en-3-ol",singleS,4,28). bond("(3β,9β)-4α-demethyl-4α-formyl-9,19-cyclolanost-24-en-3-ol",single,5,6).
+bond("(3β,9β)-4α-demethyl-4α-formyl-9,19-cyclolanost-24-en-3-ol",single,5,10). bond("(3β,9β)-4α-demethyl-4α-formyl-9,19-cyclolanost-24-en-3-ol",single,6,7). bond("(3β,9β)-4α-demethyl-4α-formyl-9,19-cyclolanost-24-en-3-ol",single,7,8).
+bond("(3β,9β)-4α-demethyl-4α-formyl-9,19-cyclolanost-24-en-3-ol",single,8,9). bond("(3β,9β)-4α-demethyl-4α-formyl-9,19-cyclolanost-24-en-3-ol",single,8,14). bond("(3β,9β)-4α-demethyl-4α-formyl-9,19-cyclolanost-24-en-3-ol",single,9,10).
+bond("(3β,9β)-4α-demethyl-4α-formyl-9,19-cyclolanost-24-en-3-ol",single,9,11).bond("(3β,9β)-4α-demethyl-4α-formyl-9,19-cyclolanost-24-en-3-ol",singleR,9,19). bond("(3β,9β)-4α-demethyl-4α-formyl-9,19-cyclolanost-24-en-3-ol",singleR,10,19).
+bond("(3β,9β)-4α-demethyl-4α-formyl-9,19-cyclolanost-24-en-3-ol",single,11,12). bond("(3β,9β)-4α-demethyl-4α-formyl-9,19-cyclolanost-24-en-3-ol",single,12,13). bond("(3β,9β)-4α-demethyl-4α-formyl-9,19-cyclolanost-24-en-3-ol",single,13,14).
+bond("(3β,9β)-4α-demethyl-4α-formyl-9,19-cyclolanost-24-en-3-ol",single,14,15). bond("(3β,9β)-4α-demethyl-4α-formyl-9,19-cyclolanost-24-en-3-ol",singleS,14,30). bond("(3β,9β)-4α-demethyl-4α-formyl-9,19-cyclolanost-24-en-3-ol",single,15,16).
+bond("(3β,9β)-4α-demethyl-4α-formyl-9,19-cyclolanost-24-en-3-ol",single,16,17). bond("(3β,9β)-4α-demethyl-4α-formyl-9,19-cyclolanost-24-en-3-ol",single,13,17). bond("(3β,9β)-4α-demethyl-4α-formyl-9,19-cyclolanost-24-en-3-ol",singleR,13,18).
+bond("(3β,9β)-4α-demethyl-4α-formyl-9,19-cyclolanost-24-en-3-ol",singleR,17,20). bond("(3β,9β)-4α-demethyl-4α-formyl-9,19-cyclolanost-24-en-3-ol",singleS,20,21). bond("(3β,9β)-4α-demethyl-4α-formyl-9,19-cyclolanost-24-en-3-ol",single,20,22).
+bond("(3β,9β)-4α-demethyl-4α-formyl-9,19-cyclolanost-24-en-3-ol",single,22,23). bond("(3β,9β)-4α-demethyl-4α-formyl-9,19-cyclolanost-24-en-3-ol",single,23,24). bond("(3β,9β)-4α-demethyl-4α-formyl-9,19-cyclolanost-24-en-3-ol",double,24,25).
+bond("(3β,9β)-4α-demethyl-4α-formyl-9,19-cyclolanost-24-en-3-ol",single,25,26). bond("(3β,9β)-4α-demethyl-4α-formyl-9,19-cyclolanost-24-en-3-ol",single,25,27). bond("(3β,9β)-4α-demethyl-4α-formyl-9,19-cyclolanost-24-en-3-ol",double,29,33).
+
 atom("(3β,9β)-4α-demethyl-4α-carboxy-9,19-cyclolanost-24-en-3-ol",1..30,carb). atom("(3β,9β)-4α-demethyl-4α-carboxy-9,19-cyclolanost-24-en-3-ol",31..33,oxyg).
 bond("(3β,9β)-4α-demethyl-4α-carboxy-9,19-cyclolanost-24-en-3-ol",single,1,2). bond("(3β,9β)-4α-demethyl-4α-carboxy-9,19-cyclolanost-24-en-3-ol",single,1,10). bond("(3β,9β)-4α-demethyl-4α-carboxy-9,19-cyclolanost-24-en-3-ol",single,2,3).
 bond("(3β,9β)-4α-demethyl-4α-carboxy-9,19-cyclolanost-24-en-3-ol",single,3,4). bond("(3β,9β)-4α-demethyl-4α-carboxy-9,19-cyclolanost-24-en-3-ol",singleR,3,31). bond("(3β,9β)-4α-demethyl-4α-carboxy-9,19-cyclolanost-24-en-3-ol",single,4,5).
-bond("(3β,9β)-4α-demethyl-4α-carboxy-9,19-cyclolanost-24-en-3-ol",singleR,4,29). 
-bond("(3β,9β)-4α-demethyl-4α-carboxy-9,19-cyclolanost-24-en-3-ol",single,29,32). 
-bond("(3β,9β)-4α-demethyl-4α-carboxy-9,19-cyclolanost-24-en-3-ol",double,29,33). 
-bond("(3β,9β)-4α-demethyl-4α-carboxy-9,19-cyclolanost-24-en-3-ol",singleS,4,28). bond("(3β,9β)-4α-demethyl-4α-carboxy-9,19-cyclolanost-24-en-3-ol",single,5,6).
+bond("(3β,9β)-4α-demethyl-4α-carboxy-9,19-cyclolanost-24-en-3-ol",singleR,4,29). bond("(3β,9β)-4α-demethyl-4α-carboxy-9,19-cyclolanost-24-en-3-ol",singleS,4,28). bond("(3β,9β)-4α-demethyl-4α-carboxy-9,19-cyclolanost-24-en-3-ol",single,5,6).
 bond("(3β,9β)-4α-demethyl-4α-carboxy-9,19-cyclolanost-24-en-3-ol",single,5,10). bond("(3β,9β)-4α-demethyl-4α-carboxy-9,19-cyclolanost-24-en-3-ol",single,6,7). bond("(3β,9β)-4α-demethyl-4α-carboxy-9,19-cyclolanost-24-en-3-ol",single,7,8).
 bond("(3β,9β)-4α-demethyl-4α-carboxy-9,19-cyclolanost-24-en-3-ol",single,8,9). bond("(3β,9β)-4α-demethyl-4α-carboxy-9,19-cyclolanost-24-en-3-ol",single,8,14). bond("(3β,9β)-4α-demethyl-4α-carboxy-9,19-cyclolanost-24-en-3-ol",single,9,10).
 bond("(3β,9β)-4α-demethyl-4α-carboxy-9,19-cyclolanost-24-en-3-ol",single,9,11).bond("(3β,9β)-4α-demethyl-4α-carboxy-9,19-cyclolanost-24-en-3-ol",singleR,9,19). bond("(3β,9β)-4α-demethyl-4α-carboxy-9,19-cyclolanost-24-en-3-ol",singleR,10,19).
@@ -43,21 +68,103 @@ bond("(3β,9β)-4α-demethyl-4α-carboxy-9,19-cyclolanost-24-en-3-ol",single,14,
 bond("(3β,9β)-4α-demethyl-4α-carboxy-9,19-cyclolanost-24-en-3-ol",single,16,17). bond("(3β,9β)-4α-demethyl-4α-carboxy-9,19-cyclolanost-24-en-3-ol",single,13,17). bond("(3β,9β)-4α-demethyl-4α-carboxy-9,19-cyclolanost-24-en-3-ol",singleR,13,18).
 bond("(3β,9β)-4α-demethyl-4α-carboxy-9,19-cyclolanost-24-en-3-ol",singleR,17,20). bond("(3β,9β)-4α-demethyl-4α-carboxy-9,19-cyclolanost-24-en-3-ol",singleS,20,21). bond("(3β,9β)-4α-demethyl-4α-carboxy-9,19-cyclolanost-24-en-3-ol",single,20,22).
 bond("(3β,9β)-4α-demethyl-4α-carboxy-9,19-cyclolanost-24-en-3-ol",single,22,23). bond("(3β,9β)-4α-demethyl-4α-carboxy-9,19-cyclolanost-24-en-3-ol",single,23,24). bond("(3β,9β)-4α-demethyl-4α-carboxy-9,19-cyclolanost-24-en-3-ol",double,24,25).
-bond("(3β,9β)-4α-demethyl-4α-carboxy-9,19-cyclolanost-24-en-3-ol",single,25,26). bond("(3β,9β)-4α-demethyl-4α-carboxy-9,19-cyclolanost-24-en-3-ol",single,25,27).
+bond("(3β,9β)-4α-demethyl-4α-carboxy-9,19-cyclolanost-24-en-3-ol",single,25,26). bond("(3β,9β)-4α-demethyl-4α-carboxy-9,19-cyclolanost-24-en-3-ol",single,25,27). bond("(3β,9β)-4α-demethyl-4α-carboxy-9,19-cyclolanost-24-en-3-ol",single,29,32).
+bond("(3β,9β)-4α-demethyl-4α-carboxy-9,19-cyclolanost-24-en-3-ol",double,29,33).
 
 atom("31-norcycloartenone",1..28,carb). atom("31-norcycloartenone",30,carb). atom("31-norcycloartenone",31,oxyg).
 bond("31-norcycloartenone",single,1,2). bond("31-norcycloartenone",single,1,10). bond("31-norcycloartenone",single,2,3).
 bond("31-norcycloartenone",single,3,4). bond("31-norcycloartenone",double,3,31). bond("31-norcycloartenone",single,4,5).
-bond("31-norcycloartenone",singleS,4,28). bond("31-norcycloartenone",single,5,6).
-bond("31-norcycloartenone",single,5,10). bond("31-norcycloartenone",single,6,7). bond("31-norcycloartenone",single,7,8).
-bond("31-norcycloartenone",single,8,9). bond("31-norcycloartenone",single,8,14). bond("31-norcycloartenone",single,9,10).
-bond("31-norcycloartenone",single,9,11).bond("31-norcycloartenone",singleR,9,19). bond("31-norcycloartenone",singleR,10,19).
-bond("31-norcycloartenone",single,11,12). bond("31-norcycloartenone",single,12,13). bond("31-norcycloartenone",single,13,14).
-bond("31-norcycloartenone",single,14,15). bond("31-norcycloartenone",singleS,14,30). bond("31-norcycloartenone",single,15,16).
-bond("31-norcycloartenone",single,16,17). bond("31-norcycloartenone",single,13,17). bond("31-norcycloartenone",singleR,13,18).
-bond("31-norcycloartenone",singleR,17,20). bond("31-norcycloartenone",singleS,20,21). bond("31-norcycloartenone",single,20,22).
-bond("31-norcycloartenone",single,22,23). bond("31-norcycloartenone",single,23,24). bond("31-norcycloartenone",double,24,25).
-bond("31-norcycloartenone",single,25,26). bond("31-norcycloartenone",single,25,27).
+bond("31-norcycloartenone",singleS,4,28). bond("31-norcycloartenone",single,5,6). bond("31-norcycloartenone",single,5,10).
+bond("31-norcycloartenone",single,6,7). bond("31-norcycloartenone",single,7,8). bond("31-norcycloartenone",single,8,9).
+bond("31-norcycloartenone",single,8,14). bond("31-norcycloartenone",single,9,10). bond("31-norcycloartenone",single,9,11).
+bond("31-norcycloartenone",singleR,9,19). bond("31-norcycloartenone",singleR,10,19). bond("31-norcycloartenone",single,11,12).
+bond("31-norcycloartenone",single,12,13). bond("31-norcycloartenone",single,13,14). bond("31-norcycloartenone",single,14,15).
+bond("31-norcycloartenone",singleS,14,30). bond("31-norcycloartenone",single,15,16). bond("31-norcycloartenone",single,16,17).
+bond("31-norcycloartenone",single,13,17). bond("31-norcycloartenone",singleR,13,18). bond("31-norcycloartenone",singleR,17,20).
+bond("31-norcycloartenone",singleS,20,21). bond("31-norcycloartenone",single,20,22). bond("31-norcycloartenone",single,22,23).
+bond("31-norcycloartenone",single,23,24). bond("31-norcycloartenone",double,24,25). bond("31-norcycloartenone",single,25,26).
+bond("31-norcycloartenone",single,25,27).
+
+atom("desmosterol",1..27,carb). atom("desmosterol",31,oxyg).
+bond("desmosterol",single,1,2). bond("desmosterol",single,1,10). bond("desmosterol",single,2,3).
+bond("desmosterol",single,3,4). bond("desmosterol",singleR,3,31). bond("desmosterol",single,4,5).
+bond("desmosterol",double,5,6). bond("desmosterol",single,5,10). bond("desmosterol",single,6,7).
+bond("desmosterol",single,7,8). bond("desmosterol",single,8,9). bond("desmosterol",single,8,14).
+bond("desmosterol",single,9,10). bond("desmosterol",single,9,11). bond("desmosterol",singleR,10,19).
+bond("desmosterol",single,11,12). bond("desmosterol",single,12,13). bond("desmosterol",single,13,14).
+bond("desmosterol",single,14,15). bond("desmosterol",single,15,16). bond("desmosterol",single,16,17).
+bond("desmosterol",single,13,17). bond("desmosterol",singleR,13,18). bond("desmosterol",singleR,17,20).
+bond("desmosterol",singleS,20,21). bond("desmosterol",single,20,22). bond("desmosterol",single,22,23).
+bond("desmosterol",single,23,24). bond("desmosterol",double,24,25). bond("desmosterol",single,25,26).
+bond("desmosterol",single,25,27).
+
+atom("cholesterol",1..27,carb). atom("cholesterol",31,oxyg).
+bond("cholesterol",single,1,2). bond("cholesterol",single,1,10). bond("cholesterol",single,2,3).
+bond("cholesterol",single,3,4). bond("cholesterol",singleR,3,31). bond("cholesterol",single,4,5).
+bond("cholesterol",double,5,6). bond("cholesterol",single,5,10). bond("cholesterol",single,6,7).
+bond("cholesterol",single,7,8). bond("cholesterol",single,8,9). bond("cholesterol",single,8,14).
+bond("cholesterol",single,9,10). bond("cholesterol",single,9,11). bond("cholesterol",singleR,10,19).
+bond("cholesterol",single,11,12). bond("cholesterol",single,12,13). bond("cholesterol",single,13,14).
+bond("cholesterol",single,14,15). bond("cholesterol",single,15,16). bond("cholesterol",single,16,17).
+bond("cholesterol",single,13,17). bond("cholesterol",singleR,13,18). bond("cholesterol",singleR,17,20).
+bond("cholesterol",singleS,20,21). bond("cholesterol",single,20,22). bond("cholesterol",single,22,23).
+bond("cholesterol",single,23,24). bond("cholesterol",single,24,25). bond("cholesterol",single,25,26).
+bond("cholesterol",single,25,27).
+
+% PWY-6944: androstenedione degradation I (aerobic)
+
+atom("androst-4-ene-3,17-dione",1..19,carb). atom("androst-4-ene-3,17-dione",20,oxyg). atom("androst-4-ene-3,17-dione",31,oxyg).
+bond("androst-4-ene-3,17-dione",single,1,2). bond("androst-4-ene-3,17-dione",single,1,10). bond("androst-4-ene-3,17-dione",single,2,3).
+bond("androst-4-ene-3,17-dione",single,3,4). bond("androst-4-ene-3,17-dione",double,3,31). bond("androst-4-ene-3,17-dione",double,4,5).
+bond("androst-4-ene-3,17-dione",single,5,6). bond("androst-4-ene-3,17-dione",single,5,10). bond("androst-4-ene-3,17-dione",single,6,7).
+bond("androst-4-ene-3,17-dione",single,7,8). bond("androst-4-ene-3,17-dione",single,8,9). bond("androst-4-ene-3,17-dione",single,8,14).
+bond("androst-4-ene-3,17-dione",single,9,10). bond("androst-4-ene-3,17-dione",single,9,11). ond("androst-4-ene-3,17-dione",singleR,10,19).
+bond("androst-4-ene-3,17-dione",single,11,12). bond("androst-4-ene-3,17-dione",single,12,13). bond("androst-4-ene-3,17-dione",single,13,14).
+bond("androst-4-ene-3,17-dione",single,14,15). bond("androst-4-ene-3,17-dione",singleS,14,30). bond("androst-4-ene-3,17-dione",single,15,16).
+bond("androst-4-ene-3,17-dione",single,16,17). bond("androst-4-ene-3,17-dione",single,13,17). bond("androst-4-ene-3,17-dione",singleR,13,18).
+bond("androst-4-ene-3,17-dione",double,17,20).
+
+atom("androsta-1,4-diene-3,17-dione",1..19,carb). atom("androsta-1,4-diene-3,17-dione",20,oxyg). atom("androsta-1,4-diene-3,17-dione",31,oxyg).
+bond("androsta-1,4-diene-3,17-dione",double,1,2). bond("androsta-1,4-diene-3,17-dione",single,1,10). bond("androsta-1,4-diene-3,17-dione",single,2,3).
+bond("androsta-1,4-diene-3,17-dione",single,3,4). bond("androsta-1,4-diene-3,17-dione",double,3,31). bond("androsta-1,4-diene-3,17-dione",double,4,5).
+bond("androsta-1,4-diene-3,17-dione",single,5,6). bond("androsta-1,4-diene-3,17-dione",single,5,10). bond("androsta-1,4-diene-3,17-dione",single,6,7).
+bond("androsta-1,4-diene-3,17-dione",single,7,8). bond("androsta-1,4-diene-3,17-dione",single,8,9). bond("androsta-1,4-diene-3,17-dione",single,8,14).
+bond("androsta-1,4-diene-3,17-dione",single,9,10). bond("androsta-1,4-diene-3,17-dione",single,9,11). ond("androsta-1,4-diene-3,17-dione",singleR,10,19).
+bond("androsta-1,4-diene-3,17-dione",single,11,12). bond("androsta-1,4-diene-3,17-dione",single,12,13). bond("androsta-1,4-diene-3,17-dione",single,13,14).
+bond("androsta-1,4-diene-3,17-dione",single,14,15). bond("androsta-1,4-diene-3,17-dione",singleS,14,30). bond("androsta-1,4-diene-3,17-dione",single,15,16).
+bond("androsta-1,4-diene-3,17-dione",single,16,17). bond("androsta-1,4-diene-3,17-dione",single,13,17). bond("androsta-1,4-diene-3,17-dione",singleR,13,18).
+bond("androsta-1,4-diene-3,17-dione",double,17,20).
+
+% Information necessary to infer new 23 hydroxylation
+atom("(22α)-hydroxy-campest-4-en-3-one",1..27,carb).  atom("(22α)-hydroxy-campest-4-en-3-one",30,carb). atom("(22α)-hydroxy-campest-4-en-3-one",31,oxyg).
+atom("(22α)-hydroxy-campest-4-en-3-one",34,oxyg). atom("(22α)-hydroxy-campest-4-en-3-one",35,carb).
+bond("(22α)-hydroxy-campest-4-en-3-one",single,1,2). bond("(22α)-hydroxy-campest-4-en-3-one",single,1,10). bond("(22α)-hydroxy-campest-4-en-3-one",single,2,3).
+bond("(22α)-hydroxy-campest-4-en-3-one",single,3,4). bond("(22α)-hydroxy-campest-4-en-3-one",double,3,31). bond("(22α)-hydroxy-campest-4-en-3-one",single,4,5).
+bond("(22α)-hydroxy-campest-4-en-3-one",double,5,6). bond("(22α)-hydroxy-campest-4-en-3-one",single,5,10). bond("(22α)-hydroxy-campest-4-en-3-one",single,6,7).
+bond("(22α)-hydroxy-campest-4-en-3-one",single,7,8). bond("(22α)-hydroxy-campest-4-en-3-one",single,8,9). bond("(22α)-hydroxy-campest-4-en-3-one",single,8,14).
+bond("(22α)-hydroxy-campest-4-en-3-one",single,9,10). bond("(22α)-hydroxy-campest-4-en-3-one",single,9,11). bond("(22α)-hydroxy-campest-4-en-3-one",singleR,10,19).
+bond("(22α)-hydroxy-campest-4-en-3-one",single,11,12). bond("(22α)-hydroxy-campest-4-en-3-one",single,12,13). bond("(22α)-hydroxy-campest-4-en-3-one",single,13,14).
+bond("(22α)-hydroxy-campest-4-en-3-one",single,14,15). bond("(22α)-hydroxy-campest-4-en-3-one",singleS,14,30). bond("(22α)-hydroxy-campest-4-en-3-one",single,15,16).
+bond("(22α)-hydroxy-campest-4-en-3-one",single,16,17). bond("(22α)-hydroxy-campest-4-en-3-one",single,13,17). bond("(22α)-hydroxy-campest-4-en-3-one",singleR,13,18).
+bond("(22α)-hydroxy-campest-4-en-3-one",singleR,17,20). bond("(22α)-hydroxy-campest-4-en-3-one",singleS,20,21). bond("(22α)-hydroxy-campest-4-en-3-one",single,20,22).
+bond("(22α)-hydroxy-campest-4-en-3-one",singleR,22,34). bond("(22α)-hydroxy-campest-4-en-3-one",single,22,23). bond("(22α)-hydroxy-campest-4-en-3-one",single,23,24).
+bond("(22α)-hydroxy-campest-4-en-3-one",single,24,25). bond("(22α)-hydroxy-campest-4-en-3-one",singleR,24,35). bond("(22α)-hydroxy-campest-4-en-3-one",single,25,26).
+bond("(22α)-hydroxy-campest-4-en-3-one",single,25,27).
+
+atom("(22R,23R)-22,23-dihydroxy-campest-4-en-3-one",1..27,carb).  atom("(22R,23R)-22,23-dihydroxy-campest-4-en-3-one",30,carb). atom("(22R,23R)-22,23-dihydroxy-campest-4-en-3-one",31,oxyg).
+atom("(22R,23R)-22,23-dihydroxy-campest-4-en-3-one",32,oxyg). atom("(22R,23R)-22,23-dihydroxy-campest-4-en-3-one",34,oxyg). atom("(22R,23R)-22,23-dihydroxy-campest-4-en-3-one",35,carb).
+bond("(22R,23R)-22,23-dihydroxy-campest-4-en-3-one",single,1,2). bond("(22R,23R)-22,23-dihydroxy-campest-4-en-3-one",single,1,10). bond("(22R,23R)-22,23-dihydroxy-campest-4-en-3-one",single,2,3).
+bond("(22R,23R)-22,23-dihydroxy-campest-4-en-3-one",single,3,4). bond("(22R,23R)-22,23-dihydroxy-campest-4-en-3-one",double,3,31). bond("(22R,23R)-22,23-dihydroxy-campest-4-en-3-one",single,4,5).
+bond("(22R,23R)-22,23-dihydroxy-campest-4-en-3-one",double,5,6). bond("(22R,23R)-22,23-dihydroxy-campest-4-en-3-one",single,5,10). bond("(22R,23R)-22,23-dihydroxy-campest-4-en-3-one",single,6,7).
+bond("(22R,23R)-22,23-dihydroxy-campest-4-en-3-one",single,7,8). bond("(22R,23R)-22,23-dihydroxy-campest-4-en-3-one",single,8,9). bond("(22R,23R)-22,23-dihydroxy-campest-4-en-3-one",single,8,14).
+bond("(22R,23R)-22,23-dihydroxy-campest-4-en-3-one",single,9,10). bond("(22R,23R)-22,23-dihydroxy-campest-4-en-3-one",single,9,11). bond("(22R,23R)-22,23-dihydroxy-campest-4-en-3-one",singleR,10,19).
+bond("(22R,23R)-22,23-dihydroxy-campest-4-en-3-one",single,11,12). bond("(22R,23R)-22,23-dihydroxy-campest-4-en-3-one",single,12,13). bond("(22R,23R)-22,23-dihydroxy-campest-4-en-3-one",single,13,14).
+bond("(22R,23R)-22,23-dihydroxy-campest-4-en-3-one",single,14,15). bond("(22R,23R)-22,23-dihydroxy-campest-4-en-3-one",singleS,14,30). bond("(22R,23R)-22,23-dihydroxy-campest-4-en-3-one",single,15,16).
+bond("(22R,23R)-22,23-dihydroxy-campest-4-en-3-one",single,16,17). bond("(22R,23R)-22,23-dihydroxy-campest-4-en-3-one",single,13,17). bond("(22R,23R)-22,23-dihydroxy-campest-4-en-3-one",singleR,13,18).
+bond("(22R,23R)-22,23-dihydroxy-campest-4-en-3-one",singleR,17,20). bond("(22R,23R)-22,23-dihydroxy-campest-4-en-3-one",singleS,20,21). bond("(22R,23R)-22,23-dihydroxy-campest-4-en-3-one",single,20,22).
+bond("(22R,23R)-22,23-dihydroxy-campest-4-en-3-one",singleR,22,34). bond("(22R,23R)-22,23-dihydroxy-campest-4-en-3-one",single,22,23). bond("(22R,23R)-22,23-dihydroxy-campest-4-en-3-one",single,23,24).
+bond("(22R,23R)-22,23-dihydroxy-campest-4-en-3-one",singleR,23,32). bond("(22R,23R)-22,23-dihydroxy-campest-4-en-3-one",single,24,25). bond("(22R,23R)-22,23-dihydroxy-campest-4-en-3-one",singleR,24,35). 
+bond("(22R,23R)-22,23-dihydroxy-campest-4-en-3-one",single,25,26). bond("(22R,23R)-22,23-dihydroxy-campest-4-en-3-one",single,25,27).
 
 % New inferred intermediates
 
@@ -86,8 +193,8 @@ bond("23-hydroxy-Δ1-2-31-norcycloartenone",single,11,12). bond("23-hydroxy-Δ1-
 bond("23-hydroxy-Δ1-2-31-norcycloartenone",single,14,15). bond("23-hydroxy-Δ1-2-31-norcycloartenone",singleS,14,30). bond("23-hydroxy-Δ1-2-31-norcycloartenone",single,15,16).
 bond("23-hydroxy-Δ1-2-31-norcycloartenone",single,16,17). bond("23-hydroxy-Δ1-2-31-norcycloartenone",single,13,17). bond("23-hydroxy-Δ1-2-31-norcycloartenone",singleR,13,18).
 bond("23-hydroxy-Δ1-2-31-norcycloartenone",singleR,17,20). bond("23-hydroxy-Δ1-2-31-norcycloartenone",singleS,20,21). bond("23-hydroxy-Δ1-2-31-norcycloartenone",single,20,22).
-bond("23-hydroxy-Δ1-2-31-norcycloartenone",single,22,23). bond("23-hydroxy-Δ1-2-31-norcycloartenone",single,23,24). bond("23-hydroxy-Δ1-2-31-norcycloartenone",single,23,32). bond("23-hydroxy-Δ1-2-31-norcycloartenone",double,24,25).
-bond("23-hydroxy-Δ1-2-31-norcycloartenone",single,25,26). bond("23-hydroxy-Δ1-2-31-norcycloartenone",single,25,27).
+bond("23-hydroxy-Δ1-2-31-norcycloartenone",single,22,23). bond("23-hydroxy-Δ1-2-31-norcycloartenone",single,23,24). bond("23-hydroxy-Δ1-2-31-norcycloartenone",singleR,23,32).
+bond("23-hydroxy-Δ1-2-31-norcycloartenone",double,24,25). bond("23-hydroxy-Δ1-2-31-norcycloartenone",single,25,26). bond("23-hydroxy-Δ1-2-31-norcycloartenone",single,25,27).
 
 % Mozukulins A and B from Chen et al., 2016
 
@@ -154,6 +261,8 @@ reaction(rxn_21827, "(3β,9β)-4α-demethyl-4α-methylhydroxy-9,19-cyclolanost-2
 reaction(rxn_21828, "(3β,9β)-4α-demethyl-4α-formyl-9,19-cyclolanost-24-en-3-ol", "(3β,9β)-4α-demethyl-4α-carboxy-9,19-cyclolanost-24-en-3-ol").
 reaction(rxn_21830, "(3β,9β)-4α-demethyl-4α-carboxy-9,19-cyclolanost-24-en-3-ol", "31-norcycloartenone").
 
+reaction(rxn66_28, "desmosterol", "cholesterol").
+
 % Information necessary to infer new Δ1-2 reduction
 % PWY-6944: androstenedione degradation I (aerobic)
 reaction(rxn_12714,"androst-4-ene-3,17-dione","androsta-1,4-diene-3,17-dione").
@@ -170,6 +279,7 @@ https://metacyc.org/META/substring-search?type=NIL&object=hydroxysteroid+dehydro
 The candidate enzyme could belong either to the short-chain dehydrogenase family (SDR) or to the aldo-ketoreductases. 
 Alternatively, the reaction could also be performed by a CYP enzyme in a CYP85 or CYP90A-like manner.
 *%
+reaction(new_23_dehydrogenation, "23-hydroxy-Δ1-2-31-norcycloartenone", "mozukulin A").
 
 % PWY66-4 and PWY-8191
 reaction(rxn66_28, "desmosterol", "cholesterol").

--- a/pathmodel/data/mozukulins_pwy.lp
+++ b/pathmodel/data/mozukulins_pwy.lp
@@ -1,0 +1,192 @@
+%*This is work in progress for a paper by Girard et al., to be submitted to Frontiers in Plant Science, and has not yet been peer reviewed. 
+*%
+
+
+%*
+Data
+Describing the starting set of metabolites
+
+atom(Compound name, Atom number, Atom type).
+bond(Compound name, Chemical bond type, Atom number1, Greater Atom number2).
+*%
+
+% Sterol from PWY-2541
+
+atom("cycloartenol",1..30,carb). atom("cycloartenol",31,oxyg).
+bond("cycloartenol",single,1,2). bond("cycloartenol",single,1,10). bond("cycloartenol",single,2,3).
+bond("cycloartenol",single,3,4). bond("cycloartenol",singleR,3,31). bond("cycloartenol",single,4,5).
+bond("cycloartenol",singleR,4,29). bond("cycloartenol",singleS,4,28). bond("cycloartenol",single,5,6).
+bond("cycloartenol",single,5,10). bond("cycloartenol",single,6,7). bond("cycloartenol",single,7,8).
+bond("cycloartenol",single,8,9). bond("cycloartenol",single,8,14). bond("cycloartenol",single,9,10).
+bond("cycloartenol",single,9,11).bond("cycloartenol",singleR,9,19). bond("cycloartenol",singleR,10,19).
+bond("cycloartenol",single,11,12). bond("cycloartenol",single,12,13). bond("cycloartenol",single,13,14).
+bond("cycloartenol",single,14,15). bond("cycloartenol",singleS,14,30). bond("cycloartenol",single,15,16).
+bond("cycloartenol",single,16,17). bond("cycloartenol",single,13,17). bond("cycloartenol",singleR,13,18).
+bond("cycloartenol",singleR,17,20). bond("cycloartenol",singleS,20,21). bond("cycloartenol",single,20,22).
+bond("cycloartenol",single,22,23). bond("cycloartenol",single,23,24). bond("cycloartenol",double,24,25).
+bond("cycloartenol",single,25,26). bond("cycloartenol",single,25,27).
+
+% Sterols from PWY-8191
+
+atom("(3β,9β)-4α-demethyl-4α-carboxy-9,19-cyclolanost-24-en-3-ol",1..30,carb). atom("(3β,9β)-4α-demethyl-4α-carboxy-9,19-cyclolanost-24-en-3-ol",31..33,oxyg).
+bond("(3β,9β)-4α-demethyl-4α-carboxy-9,19-cyclolanost-24-en-3-ol",single,1,2). bond("(3β,9β)-4α-demethyl-4α-carboxy-9,19-cyclolanost-24-en-3-ol",single,1,10). bond("(3β,9β)-4α-demethyl-4α-carboxy-9,19-cyclolanost-24-en-3-ol",single,2,3).
+bond("(3β,9β)-4α-demethyl-4α-carboxy-9,19-cyclolanost-24-en-3-ol",single,3,4). bond("(3β,9β)-4α-demethyl-4α-carboxy-9,19-cyclolanost-24-en-3-ol",singleR,3,31). bond("(3β,9β)-4α-demethyl-4α-carboxy-9,19-cyclolanost-24-en-3-ol",single,4,5).
+bond("(3β,9β)-4α-demethyl-4α-carboxy-9,19-cyclolanost-24-en-3-ol",singleR,4,29). 
+bond("(3β,9β)-4α-demethyl-4α-carboxy-9,19-cyclolanost-24-en-3-ol",single,29,32). 
+bond("(3β,9β)-4α-demethyl-4α-carboxy-9,19-cyclolanost-24-en-3-ol",double,29,33). 
+bond("(3β,9β)-4α-demethyl-4α-carboxy-9,19-cyclolanost-24-en-3-ol",singleS,4,28). bond("(3β,9β)-4α-demethyl-4α-carboxy-9,19-cyclolanost-24-en-3-ol",single,5,6).
+bond("(3β,9β)-4α-demethyl-4α-carboxy-9,19-cyclolanost-24-en-3-ol",single,5,10). bond("(3β,9β)-4α-demethyl-4α-carboxy-9,19-cyclolanost-24-en-3-ol",single,6,7). bond("(3β,9β)-4α-demethyl-4α-carboxy-9,19-cyclolanost-24-en-3-ol",single,7,8).
+bond("(3β,9β)-4α-demethyl-4α-carboxy-9,19-cyclolanost-24-en-3-ol",single,8,9). bond("(3β,9β)-4α-demethyl-4α-carboxy-9,19-cyclolanost-24-en-3-ol",single,8,14). bond("(3β,9β)-4α-demethyl-4α-carboxy-9,19-cyclolanost-24-en-3-ol",single,9,10).
+bond("(3β,9β)-4α-demethyl-4α-carboxy-9,19-cyclolanost-24-en-3-ol",single,9,11).bond("(3β,9β)-4α-demethyl-4α-carboxy-9,19-cyclolanost-24-en-3-ol",singleR,9,19). bond("(3β,9β)-4α-demethyl-4α-carboxy-9,19-cyclolanost-24-en-3-ol",singleR,10,19).
+bond("(3β,9β)-4α-demethyl-4α-carboxy-9,19-cyclolanost-24-en-3-ol",single,11,12). bond("(3β,9β)-4α-demethyl-4α-carboxy-9,19-cyclolanost-24-en-3-ol",single,12,13). bond("(3β,9β)-4α-demethyl-4α-carboxy-9,19-cyclolanost-24-en-3-ol",single,13,14).
+bond("(3β,9β)-4α-demethyl-4α-carboxy-9,19-cyclolanost-24-en-3-ol",single,14,15). bond("(3β,9β)-4α-demethyl-4α-carboxy-9,19-cyclolanost-24-en-3-ol",singleS,14,30). bond("(3β,9β)-4α-demethyl-4α-carboxy-9,19-cyclolanost-24-en-3-ol",single,15,16).
+bond("(3β,9β)-4α-demethyl-4α-carboxy-9,19-cyclolanost-24-en-3-ol",single,16,17). bond("(3β,9β)-4α-demethyl-4α-carboxy-9,19-cyclolanost-24-en-3-ol",single,13,17). bond("(3β,9β)-4α-demethyl-4α-carboxy-9,19-cyclolanost-24-en-3-ol",singleR,13,18).
+bond("(3β,9β)-4α-demethyl-4α-carboxy-9,19-cyclolanost-24-en-3-ol",singleR,17,20). bond("(3β,9β)-4α-demethyl-4α-carboxy-9,19-cyclolanost-24-en-3-ol",singleS,20,21). bond("(3β,9β)-4α-demethyl-4α-carboxy-9,19-cyclolanost-24-en-3-ol",single,20,22).
+bond("(3β,9β)-4α-demethyl-4α-carboxy-9,19-cyclolanost-24-en-3-ol",single,22,23). bond("(3β,9β)-4α-demethyl-4α-carboxy-9,19-cyclolanost-24-en-3-ol",single,23,24). bond("(3β,9β)-4α-demethyl-4α-carboxy-9,19-cyclolanost-24-en-3-ol",double,24,25).
+bond("(3β,9β)-4α-demethyl-4α-carboxy-9,19-cyclolanost-24-en-3-ol",single,25,26). bond("(3β,9β)-4α-demethyl-4α-carboxy-9,19-cyclolanost-24-en-3-ol",single,25,27).
+
+atom("31-norcycloartenone",1..28,carb). atom("31-norcycloartenone",30,carb). atom("31-norcycloartenone",31,oxyg).
+bond("31-norcycloartenone",single,1,2). bond("31-norcycloartenone",single,1,10). bond("31-norcycloartenone",single,2,3).
+bond("31-norcycloartenone",single,3,4). bond("31-norcycloartenone",double,3,31). bond("31-norcycloartenone",single,4,5).
+bond("31-norcycloartenone",singleS,4,28). bond("31-norcycloartenone",single,5,6).
+bond("31-norcycloartenone",single,5,10). bond("31-norcycloartenone",single,6,7). bond("31-norcycloartenone",single,7,8).
+bond("31-norcycloartenone",single,8,9). bond("31-norcycloartenone",single,8,14). bond("31-norcycloartenone",single,9,10).
+bond("31-norcycloartenone",single,9,11).bond("31-norcycloartenone",singleR,9,19). bond("31-norcycloartenone",singleR,10,19).
+bond("31-norcycloartenone",single,11,12). bond("31-norcycloartenone",single,12,13). bond("31-norcycloartenone",single,13,14).
+bond("31-norcycloartenone",single,14,15). bond("31-norcycloartenone",singleS,14,30). bond("31-norcycloartenone",single,15,16).
+bond("31-norcycloartenone",single,16,17). bond("31-norcycloartenone",single,13,17). bond("31-norcycloartenone",singleR,13,18).
+bond("31-norcycloartenone",singleR,17,20). bond("31-norcycloartenone",singleS,20,21). bond("31-norcycloartenone",single,20,22).
+bond("31-norcycloartenone",single,22,23). bond("31-norcycloartenone",single,23,24). bond("31-norcycloartenone",double,24,25).
+bond("31-norcycloartenone",single,25,26). bond("31-norcycloartenone",single,25,27).
+
+% New inferred intermediates
+
+atom("Δ1-2,31-norcycloartenone",1..28,carb). atom("Δ1-2,31-norcycloartenone",30,carb). atom("Δ1-2,31-norcycloartenone",31,oxyg).
+bond("Δ1-2,31-norcycloartenone",double,1,2). bond("Δ1-2,31-norcycloartenone",single,1,10). bond("Δ1-2,31-norcycloartenone",single,2,3).
+bond("Δ1-2,31-norcycloartenone",single,3,4). bond("Δ1-2,31-norcycloartenone",double,3,31). bond("Δ1-2,31-norcycloartenone",single,4,5).
+bond("Δ1-2,31-norcycloartenone",singleS,4,28). bond("Δ1-2,31-norcycloartenone",single,5,6).
+bond("Δ1-2,31-norcycloartenone",single,5,10). bond("Δ1-2,31-norcycloartenone",single,6,7). bond("Δ1-2,31-norcycloartenone",single,7,8).
+bond("Δ1-2,31-norcycloartenone",single,8,9). bond("Δ1-2,31-norcycloartenone",single,8,14). bond("Δ1-2,31-norcycloartenone",single,9,10).
+bond("Δ1-2,31-norcycloartenone",single,9,11).bond("Δ1-2,31-norcycloartenone",singleR,9,19). bond("Δ1-2,31-norcycloartenone",singleR,10,19).
+bond("Δ1-2,31-norcycloartenone",single,11,12). bond("Δ1-2,31-norcycloartenone",single,12,13). bond("Δ1-2,31-norcycloartenone",single,13,14).
+bond("Δ1-2,31-norcycloartenone",single,14,15). bond("Δ1-2,31-norcycloartenone",singleS,14,30). bond("Δ1-2,31-norcycloartenone",single,15,16).
+bond("Δ1-2,31-norcycloartenone",single,16,17). bond("Δ1-2,31-norcycloartenone",single,13,17). bond("Δ1-2,31-norcycloartenone",singleR,13,18).
+bond("Δ1-2,31-norcycloartenone",singleR,17,20). bond("Δ1-2,31-norcycloartenone",singleS,20,21). bond("Δ1-2,31-norcycloartenone",single,20,22).
+bond("Δ1-2,31-norcycloartenone",single,22,23). bond("Δ1-2,31-norcycloartenone",single,23,24). bond("Δ1-2,31-norcycloartenone",double,24,25).
+bond("Δ1-2,31-norcycloartenone",single,25,26). bond("Δ1-2,31-norcycloartenone",single,25,27).
+
+atom("23-hydroxy-Δ1-2-31-norcycloartenone",1..28,carb). atom("23-hydroxy-Δ1-2-31-norcycloartenone",30,carb). atom("23-hydroxy-Δ1-2-31-norcycloartenone",31..32,oxyg).
+bond("23-hydroxy-Δ1-2-31-norcycloartenone",double,1,2). bond("23-hydroxy-Δ1-2-31-norcycloartenone",single,1,10). bond("23-hydroxy-Δ1-2-31-norcycloartenone",single,2,3).
+bond("23-hydroxy-Δ1-2-31-norcycloartenone",single,3,4). bond("23-hydroxy-Δ1-2-31-norcycloartenone",double,3,31). bond("23-hydroxy-Δ1-2-31-norcycloartenone",single,4,5).
+bond("23-hydroxy-Δ1-2-31-norcycloartenone",singleS,4,28). bond("23-hydroxy-Δ1-2-31-norcycloartenone",single,5,6).
+bond("23-hydroxy-Δ1-2-31-norcycloartenone",single,5,10). bond("23-hydroxy-Δ1-2-31-norcycloartenone",single,6,7). bond("23-hydroxy-Δ1-2-31-norcycloartenone",single,7,8).
+bond("23-hydroxy-Δ1-2-31-norcycloartenone",single,8,9). bond("23-hydroxy-Δ1-2-31-norcycloartenone",single,8,14). bond("23-hydroxy-Δ1-2-31-norcycloartenone",single,9,10).
+bond("23-hydroxy-Δ1-2-31-norcycloartenone",single,9,11).bond("23-hydroxy-Δ1-2-31-norcycloartenone",singleR,9,19). bond("23-hydroxy-Δ1-2-31-norcycloartenone",singleR,10,19).
+bond("23-hydroxy-Δ1-2-31-norcycloartenone",single,11,12). bond("23-hydroxy-Δ1-2-31-norcycloartenone",single,12,13). bond("23-hydroxy-Δ1-2-31-norcycloartenone",single,13,14).
+bond("23-hydroxy-Δ1-2-31-norcycloartenone",single,14,15). bond("23-hydroxy-Δ1-2-31-norcycloartenone",singleS,14,30). bond("23-hydroxy-Δ1-2-31-norcycloartenone",single,15,16).
+bond("23-hydroxy-Δ1-2-31-norcycloartenone",single,16,17). bond("23-hydroxy-Δ1-2-31-norcycloartenone",single,13,17). bond("23-hydroxy-Δ1-2-31-norcycloartenone",singleR,13,18).
+bond("23-hydroxy-Δ1-2-31-norcycloartenone",singleR,17,20). bond("23-hydroxy-Δ1-2-31-norcycloartenone",singleS,20,21). bond("23-hydroxy-Δ1-2-31-norcycloartenone",single,20,22).
+bond("23-hydroxy-Δ1-2-31-norcycloartenone",single,22,23). bond("23-hydroxy-Δ1-2-31-norcycloartenone",single,23,24). bond("23-hydroxy-Δ1-2-31-norcycloartenone",single,23,32). bond("23-hydroxy-Δ1-2-31-norcycloartenone",double,24,25).
+bond("23-hydroxy-Δ1-2-31-norcycloartenone",single,25,26). bond("23-hydroxy-Δ1-2-31-norcycloartenone",single,25,27).
+
+% Mozukulins A and B from Chen et al., 2016
+
+atom("mozukulin A",1..28,carb). atom("mozukulin A",30,carb). atom("mozukulin A",31..32,oxyg).
+bond("mozukulin A",double,1,2). bond("mozukulin A",single,1,10). bond("mozukulin A",single,2,3).
+bond("mozukulin A",single,3,4). bond("mozukulin A",double,3,31). bond("mozukulin A",single,4,5).
+bond("mozukulin A",singleS,4,28). bond("mozukulin A",single,5,6).
+bond("mozukulin A",single,5,10). bond("mozukulin A",single,6,7). bond("mozukulin A",single,7,8).
+bond("mozukulin A",single,8,9). bond("mozukulin A",single,8,14). bond("mozukulin A",single,9,10).
+bond("mozukulin A",single,9,11).bond("mozukulin A",singleR,9,19). bond("mozukulin A",singleR,10,19).
+bond("mozukulin A",single,11,12). bond("mozukulin A",single,12,13). bond("mozukulin A",single,13,14).
+bond("mozukulin A",single,14,15). bond("mozukulin A",singleS,14,30). bond("mozukulin A",single,15,16).
+bond("mozukulin A",single,16,17). bond("mozukulin A",single,13,17). bond("mozukulin A",singleR,13,18).
+bond("mozukulin A",singleR,17,20). bond("mozukulin A",singleS,20,21). bond("mozukulin A",single,20,22).
+bond("mozukulin A",single,22,23). bond("mozukulin A",single,23,24). bond("mozukulin A",double,24,25).
+bond("mozukulin A",single,25,26). bond("mozukulin A",single,25,27). bond("mozukulin A",double,23,32).
+
+
+atom("mozukulin B",1..28,carb). atom("mozukulin B",30,carb). atom("mozukulin B",31..32,oxyg).
+bond("mozukulin B",double,1,2). bond("mozukulin B",single,1,10). bond("mozukulin B",single,2,3).
+bond("mozukulin B",single,3,4). bond("mozukulin B",double,3,31). bond("mozukulin B",single,4,5).
+bond("mozukulin B",singleS,4,28). bond("mozukulin B",single,5,6).
+bond("mozukulin B",single,5,10). bond("mozukulin B",single,6,7). bond("mozukulin B",single,7,8).
+bond("mozukulin B",single,8,9). bond("mozukulin B",single,8,14). bond("mozukulin B",single,9,10).
+bond("mozukulin B",single,9,11).bond("mozukulin B",singleR,9,19). bond("mozukulin B",singleR,10,19).
+bond("mozukulin B",single,11,12). bond("mozukulin B",single,12,13). bond("mozukulin B",single,13,14).
+bond("mozukulin B",single,14,15). bond("mozukulin B",singleS,14,30). bond("mozukulin B",single,15,16).
+bond("mozukulin B",single,16,17). bond("mozukulin B",single,13,17). bond("mozukulin B",singleR,13,18).
+bond("mozukulin B",singleR,17,20). bond("mozukulin B",singleS,20,21). bond("mozukulin B",single,20,22).
+bond("mozukulin B",single,22,23). bond("mozukulin B",single,23,24). bond("mozukulin B",single,24,25).
+bond("mozukulin B",single,25,26). bond("mozukulin B",single,25,27). bond("mozukulin B",double,23,32).
+
+
+%*
+Shared domain
+Definition of sterane
+Based on the wikipedia structure: https://fr.wikipedia.org/wiki/St%C3%A9rane#/media/File:Steran_num_ABCD.svg
+*%
+
+atomDomain(sterane,1,carb). atomDomain(sterane,2,carb). atomDomain(sterane,3,carb).
+atomDomain(sterane,4,carb). atomDomain(sterane,5,carb). atomDomain(sterane,6,carb).
+atomDomain(sterane,7,carb). atomDomain(sterane,8,carb). atomDomain(sterane,9,carb).
+atomDomain(sterane,10,carb). atomDomain(sterane,11,carb). atomDomain(sterane,12,carb).
+atomDomain(sterane,13,carb). atomDomain(sterane,14,carb). atomDomain(sterane,15,carb).
+atomDomain(sterane,16,carb). atomDomain(sterane,17,carb).
+bondDomain(sterane,variable,1,2). bondDomain(sterane,variable,1,10). bondDomain(sterane,variable,2,3).
+bondDomain(sterane,variable,3,4). bondDomain(sterane,variable,4,5). bondDomain(sterane,variable,5,6).
+bondDomain(sterane,variable,5,10). bondDomain(sterane,variable,6,7). bondDomain(sterane,variable,7,8).
+bondDomain(sterane,variable,8,9). bondDomain(sterane,variable,8,14). bondDomain(sterane,variable,9,10).
+bondDomain(sterane,variable,9,11). bondDomain(sterane,variable,11,12). bondDomain(sterane,variable,12,13).
+bondDomain(sterane,variable,13,14). bondDomain(sterane,variable,13,17). bondDomain(sterane,variable,14,15).
+bondDomain(sterane,variable,15,16). bondDomain(sterane,variable,16,17).
+
+
+%* Known reactions
+%%%%%%%%%%%%%%%%%%%
+reaction(Reaction type (name), Compound 1 [, Active site atom number], [Compound 2 , Active site atom number], Resulting compound)
+*%
+
+% Reactions from PWY-8191: cholesterol biosynthesis (algae, late side-chain reductase) 
+
+reaction(rxn_21826, "cycloartenol","(3β,9β)-4α-demethyl-4α-methylhydroxy-9,19-cyclolanost-24-en-3-ol").
+reaction(rxn_21827, "(3β,9β)-4α-demethyl-4α-methylhydroxy-9,19-cyclolanost-24-en-3-ol", "(3β,9β)-4α-demethyl-4α-formyl-9,19-cyclolanost-24-en-3-ol").
+reaction(rxn_21828, "(3β,9β)-4α-demethyl-4α-formyl-9,19-cyclolanost-24-en-3-ol", "(3β,9β)-4α-demethyl-4α-carboxy-9,19-cyclolanost-24-en-3-ol").
+reaction(rxn_21830, "(3β,9β)-4α-demethyl-4α-carboxy-9,19-cyclolanost-24-en-3-ol", "31-norcycloartenone").
+
+% Information necessary to infer new Δ1-2 reduction
+% PWY-6944: androstenedione degradation I (aerobic)
+reaction(rxn_12714,"androst-4-ene-3,17-dione","androsta-1,4-diene-3,17-dione). 
+% corresponding metacyc general reactions (EC 1.3.99.4)
+reaction(3-OXOSTEROID-1-DEHYDROGENASE-RXN,"a 3-oxosteroid", "a 3-oxo-Δ1-steroid").
+
+% Information necessary to infer new 23 hydroxylation
+reaction(rxn_11530, "(22α)-hydroxy-campest-4-en-3-one", "(22R,23R)-22,23-dihydroxy-campest-4-en-3-one").
+
+% Information necessary to infer new 23 dehydrogenation
+Here we have to define the general concept of steroid dehydrogenation based on the numerous occurrences on various positions: 3, 7, 11, 12, 17, 20 
+https://metacyc.org/META/substring-search?type=NIL&object=hydroxysteroid+dehydrogenase&quickSearch=Quick+Search#ENZYME
+The candidate enzyme could belong either to the short-chain dehydrogenase family (SDR) or to the aldo-ketoreductases. 
+Alternatively, the reaction could also be performed by a CYP enzyme in a CYP85 or CYP90A-like manner.
+
+% PWY66-4 and PWY-8191
+reaction(rxn66_28, "desmosterol", "cholesterol").
+
+
+% Source molecule for inference.
+
+source("cycloartenol").
+
+
+% Initiation of incremental grounding.
+init(pathway("cycloartenol","cholesterol")).
+goal(pathway("cycloartenol","mozukulin B")).
+
+
+%* Expected inferred reactions: 
+
+reaction(delta1_2_ketoreduction,31-norcycloartenone,"Δ1-2,31-norcycloartenone").
+reaction(23-hydroxylation, "Δ1-2,31-norcycloartenone", "23-hydroxy-Δ1-2-31-norcycloartenone").
+reaction(23_hydroxysteroid_reduction, "23-hydroxy-Δ1-2-31-norcycloartenone", "mozukulin A").
+reaction(delta24reduction, "mozukulin A", "mozukulin B"). 
+*%

--- a/pathmodel/data/mozukulins_pwy.lp
+++ b/pathmodel/data/mozukulins_pwy.lp
@@ -28,34 +28,6 @@ bond("cycloartenol",single,25,26). bond("cycloartenol",single,25,27).
 
 % Sterols from PWY-8191
 
-atom("(3β,9β)-4α-demethyl-4α-methylhydroxy-9,19-cyclolanost-24-en-3-ol",1..30,carb). atom("(3β,9β)-4α-demethyl-4α-methylhydroxy-9,19-cyclolanost-24-en-3-ol",31,oxyg). atom("(3β,9β)-4α-demethyl-4α-methylhydroxy-9,19-cyclolanost-24-en-3-ol",33,oxyg).
-bond("(3β,9β)-4α-demethyl-4α-methylhydroxy-9,19-cyclolanost-24-en-3-ol",single,1,2). bond("(3β,9β)-4α-demethyl-4α-methylhydroxy-9,19-cyclolanost-24-en-3-ol",single,1,10). bond("(3β,9β)-4α-demethyl-4α-methylhydroxy-9,19-cyclolanost-24-en-3-ol",single,2,3).
-bond("(3β,9β)-4α-demethyl-4α-methylhydroxy-9,19-cyclolanost-24-en-3-ol",single,3,4). bond("(3β,9β)-4α-demethyl-4α-methylhydroxy-9,19-cyclolanost-24-en-3-ol",singleR,3,31). bond("(3β,9β)-4α-demethyl-4α-methylhydroxy-9,19-cyclolanost-24-en-3-ol",single,4,5).
-bond("(3β,9β)-4α-demethyl-4α-methylhydroxy-9,19-cyclolanost-24-en-3-ol",singleR,4,29). bond("(3β,9β)-4α-demethyl-4α-methylhydroxy-9,19-cyclolanost-24-en-3-ol",singleS,4,28). bond("(3β,9β)-4α-demethyl-4α-methylhydroxy-9,19-cyclolanost-24-en-3-ol",single,5,6).
-bond("(3β,9β)-4α-demethyl-4α-methylhydroxy-9,19-cyclolanost-24-en-3-ol",single,5,10). bond("(3β,9β)-4α-demethyl-4α-methylhydroxy-9,19-cyclolanost-24-en-3-ol",single,6,7). bond("(3β,9β)-4α-demethyl-4α-methylhydroxy-9,19-cyclolanost-24-en-3-ol",single,7,8).
-bond("(3β,9β)-4α-demethyl-4α-methylhydroxy-9,19-cyclolanost-24-en-3-ol",single,8,9). bond("(3β,9β)-4α-demethyl-4α-methylhydroxy-9,19-cyclolanost-24-en-3-ol",single,8,14). bond("(3β,9β)-4α-demethyl-4α-methylhydroxy-9,19-cyclolanost-24-en-3-ol",single,9,10).
-bond("(3β,9β)-4α-demethyl-4α-methylhydroxy-9,19-cyclolanost-24-en-3-ol",single,9,11).bond("(3β,9β)-4α-demethyl-4α-methylhydroxy-9,19-cyclolanost-24-en-3-ol",singleR,9,19). bond("(3β,9β)-4α-demethyl-4α-methylhydroxy-9,19-cyclolanost-24-en-3-ol",singleR,10,19).
-bond("(3β,9β)-4α-demethyl-4α-methylhydroxy-9,19-cyclolanost-24-en-3-ol",single,11,12). bond("(3β,9β)-4α-demethyl-4α-methylhydroxy-9,19-cyclolanost-24-en-3-ol",single,12,13). bond("(3β,9β)-4α-demethyl-4α-methylhydroxy-9,19-cyclolanost-24-en-3-ol",single,13,14).
-bond("(3β,9β)-4α-demethyl-4α-methylhydroxy-9,19-cyclolanost-24-en-3-ol",single,14,15). bond("(3β,9β)-4α-demethyl-4α-methylhydroxy-9,19-cyclolanost-24-en-3-ol",singleS,14,30). bond("(3β,9β)-4α-demethyl-4α-methylhydroxy-9,19-cyclolanost-24-en-3-ol",single,15,16).
-bond("(3β,9β)-4α-demethyl-4α-methylhydroxy-9,19-cyclolanost-24-en-3-ol",single,16,17). bond("(3β,9β)-4α-demethyl-4α-methylhydroxy-9,19-cyclolanost-24-en-3-ol",single,13,17). bond("(3β,9β)-4α-demethyl-4α-methylhydroxy-9,19-cyclolanost-24-en-3-ol",singleR,13,18).
-bond("(3β,9β)-4α-demethyl-4α-methylhydroxy-9,19-cyclolanost-24-en-3-ol",singleR,17,20). bond("(3β,9β)-4α-demethyl-4α-methylhydroxy-9,19-cyclolanost-24-en-3-ol",singleS,20,21). bond("(3β,9β)-4α-demethyl-4α-methylhydroxy-9,19-cyclolanost-24-en-3-ol",single,20,22).
-bond("(3β,9β)-4α-demethyl-4α-methylhydroxy-9,19-cyclolanost-24-en-3-ol",single,22,23). bond("(3β,9β)-4α-demethyl-4α-methylhydroxy-9,19-cyclolanost-24-en-3-ol",single,23,24). bond("(3β,9β)-4α-demethyl-4α-methylhydroxy-9,19-cyclolanost-24-en-3-ol",double,24,25).
-bond("(3β,9β)-4α-demethyl-4α-methylhydroxy-9,19-cyclolanost-24-en-3-ol",single,25,26). bond("(3β,9β)-4α-demethyl-4α-methylhydroxy-9,19-cyclolanost-24-en-3-ol",single,25,27). bond("(3β,9β)-4α-demethyl-4α-methylhydroxy-9,19-cyclolanost-24-en-3-ol",single,29,33).
-
-atom("(3β,9β)-4α-demethyl-4α-formyl-9,19-cyclolanost-24-en-3-ol",1..30,carb). atom("(3β,9β)-4α-demethyl-4α-formyl-9,19-cyclolanost-24-en-3-ol",31,oxyg). atom("(3β,9β)-4α-demethyl-4α-formyl-9,19-cyclolanost-24-en-3-ol",33,oxyg).
-bond("(3β,9β)-4α-demethyl-4α-formyl-9,19-cyclolanost-24-en-3-ol",single,1,2). bond("(3β,9β)-4α-demethyl-4α-formyl-9,19-cyclolanost-24-en-3-ol",single,1,10). bond("(3β,9β)-4α-demethyl-4α-formyl-9,19-cyclolanost-24-en-3-ol",single,2,3).
-bond("(3β,9β)-4α-demethyl-4α-formyl-9,19-cyclolanost-24-en-3-ol",single,3,4). bond("(3β,9β)-4α-demethyl-4α-formyl-9,19-cyclolanost-24-en-3-ol",singleR,3,31). bond("(3β,9β)-4α-demethyl-4α-formyl-9,19-cyclolanost-24-en-3-ol",single,4,5).
-bond("(3β,9β)-4α-demethyl-4α-formyl-9,19-cyclolanost-24-en-3-ol",singleR,4,29). bond("(3β,9β)-4α-demethyl-4α-formyl-9,19-cyclolanost-24-en-3-ol",singleS,4,28). bond("(3β,9β)-4α-demethyl-4α-formyl-9,19-cyclolanost-24-en-3-ol",single,5,6).
-bond("(3β,9β)-4α-demethyl-4α-formyl-9,19-cyclolanost-24-en-3-ol",single,5,10). bond("(3β,9β)-4α-demethyl-4α-formyl-9,19-cyclolanost-24-en-3-ol",single,6,7). bond("(3β,9β)-4α-demethyl-4α-formyl-9,19-cyclolanost-24-en-3-ol",single,7,8).
-bond("(3β,9β)-4α-demethyl-4α-formyl-9,19-cyclolanost-24-en-3-ol",single,8,9). bond("(3β,9β)-4α-demethyl-4α-formyl-9,19-cyclolanost-24-en-3-ol",single,8,14). bond("(3β,9β)-4α-demethyl-4α-formyl-9,19-cyclolanost-24-en-3-ol",single,9,10).
-bond("(3β,9β)-4α-demethyl-4α-formyl-9,19-cyclolanost-24-en-3-ol",single,9,11).bond("(3β,9β)-4α-demethyl-4α-formyl-9,19-cyclolanost-24-en-3-ol",singleR,9,19). bond("(3β,9β)-4α-demethyl-4α-formyl-9,19-cyclolanost-24-en-3-ol",singleR,10,19).
-bond("(3β,9β)-4α-demethyl-4α-formyl-9,19-cyclolanost-24-en-3-ol",single,11,12). bond("(3β,9β)-4α-demethyl-4α-formyl-9,19-cyclolanost-24-en-3-ol",single,12,13). bond("(3β,9β)-4α-demethyl-4α-formyl-9,19-cyclolanost-24-en-3-ol",single,13,14).
-bond("(3β,9β)-4α-demethyl-4α-formyl-9,19-cyclolanost-24-en-3-ol",single,14,15). bond("(3β,9β)-4α-demethyl-4α-formyl-9,19-cyclolanost-24-en-3-ol",singleS,14,30). bond("(3β,9β)-4α-demethyl-4α-formyl-9,19-cyclolanost-24-en-3-ol",single,15,16).
-bond("(3β,9β)-4α-demethyl-4α-formyl-9,19-cyclolanost-24-en-3-ol",single,16,17). bond("(3β,9β)-4α-demethyl-4α-formyl-9,19-cyclolanost-24-en-3-ol",single,13,17). bond("(3β,9β)-4α-demethyl-4α-formyl-9,19-cyclolanost-24-en-3-ol",singleR,13,18).
-bond("(3β,9β)-4α-demethyl-4α-formyl-9,19-cyclolanost-24-en-3-ol",singleR,17,20). bond("(3β,9β)-4α-demethyl-4α-formyl-9,19-cyclolanost-24-en-3-ol",singleS,20,21). bond("(3β,9β)-4α-demethyl-4α-formyl-9,19-cyclolanost-24-en-3-ol",single,20,22).
-bond("(3β,9β)-4α-demethyl-4α-formyl-9,19-cyclolanost-24-en-3-ol",single,22,23). bond("(3β,9β)-4α-demethyl-4α-formyl-9,19-cyclolanost-24-en-3-ol",single,23,24). bond("(3β,9β)-4α-demethyl-4α-formyl-9,19-cyclolanost-24-en-3-ol",double,24,25).
-bond("(3β,9β)-4α-demethyl-4α-formyl-9,19-cyclolanost-24-en-3-ol",single,25,26). bond("(3β,9β)-4α-demethyl-4α-formyl-9,19-cyclolanost-24-en-3-ol",single,25,27). bond("(3β,9β)-4α-demethyl-4α-formyl-9,19-cyclolanost-24-en-3-ol",double,29,33).
-
 atom("(3β,9β)-4α-demethyl-4α-carboxy-9,19-cyclolanost-24-en-3-ol",1..30,carb). atom("(3β,9β)-4α-demethyl-4α-carboxy-9,19-cyclolanost-24-en-3-ol",31..33,oxyg).
 bond("(3β,9β)-4α-demethyl-4α-carboxy-9,19-cyclolanost-24-en-3-ol",single,1,2). bond("(3β,9β)-4α-demethyl-4α-carboxy-9,19-cyclolanost-24-en-3-ol",single,1,10). bond("(3β,9β)-4α-demethyl-4α-carboxy-9,19-cyclolanost-24-en-3-ol",single,2,3).
 bond("(3β,9β)-4α-demethyl-4α-carboxy-9,19-cyclolanost-24-en-3-ol",single,3,4). bond("(3β,9β)-4α-demethyl-4α-carboxy-9,19-cyclolanost-24-en-3-ol",singleR,3,31). bond("(3β,9β)-4α-demethyl-4α-carboxy-9,19-cyclolanost-24-en-3-ol",single,4,5).
@@ -640,9 +612,7 @@ reaction(Reaction type (name), Compound 1 [, Active site atom number], [Compound
 
 % Reactions from PWY-8191: cholesterol biosynthesis (algae, late side-chain reductase) 
 
-reaction(rxn_21826, "cycloartenol","(3β,9β)-4α-demethyl-4α-methylhydroxy-9,19-cyclolanost-24-en-3-ol").
-reaction(rxn_21827, "(3β,9β)-4α-demethyl-4α-methylhydroxy-9,19-cyclolanost-24-en-3-ol", "(3β,9β)-4α-demethyl-4α-formyl-9,19-cyclolanost-24-en-3-ol").
-reaction(rxn_21828, "(3β,9β)-4α-demethyl-4α-formyl-9,19-cyclolanost-24-en-3-ol", "(3β,9β)-4α-demethyl-4α-carboxy-9,19-cyclolanost-24-en-3-ol").
+reaction(rxn_21829, "cycloartenol", "(3β,9β)-4α-demethyl-4α-carboxy-9,19-cyclolanost-24-en-3-ol").
 reaction(rxn_21830, "(3β,9β)-4α-demethyl-4α-carboxy-9,19-cyclolanost-24-en-3-ol", "31-norcycloartenone").
 
 reaction(rxn_21831, "31-norcycloartenone", "31-norcycloartenol").

--- a/pathmodel/data/mozukulins_pwy.lp
+++ b/pathmodel/data/mozukulins_pwy.lp
@@ -85,6 +85,178 @@ bond("31-norcycloartenone",singleS,20,21). bond("31-norcycloartenone",single,20,
 bond("31-norcycloartenone",single,23,24). bond("31-norcycloartenone",double,24,25). bond("31-norcycloartenone",single,25,26).
 bond("31-norcycloartenone",single,25,27).
 
+atom("31-norcycloartenol",1..28,carb). atom("31-norcycloartenol",30,carb). atom("31-norcycloartenol",31,oxyg).
+bond("31-norcycloartenol",single,1,2). bond("31-norcycloartenol",single,1,10). bond("31-norcycloartenol",single,2,3).
+bond("31-norcycloartenol",single,3,4). bond("31-norcycloartenol",double,3,31). bond("31-norcycloartenol",single,4,5).
+bond("31-norcycloartenol",singleS,4,28). bond("31-norcycloartenol",single,5,6). bond("31-norcycloartenol",single,5,10).
+bond("31-norcycloartenol",single,6,7). bond("31-norcycloartenol",single,7,8). bond("31-norcycloartenol",double,8,9).
+bond("31-norcycloartenol",single,8,14). bond("31-norcycloartenol",single,9,10). bond("31-norcycloartenol",single,9,11).
+bond("31-norcycloartenol",singleR,10,19). bond("31-norcycloartenol",single,11,12). bond("31-norcycloartenol",single,12,13).
+bond("31-norcycloartenol",single,13,14). bond("31-norcycloartenol",single,14,15). bond("31-norcycloartenol",single,15,16).
+bond("31-norcycloartenol",single,16,17). bond("31-norcycloartenol",single,13,17). bond("31-norcycloartenol",singleR,13,18).
+bond("31-norcycloartenol",singleR,17,20). bond("31-norcycloartenol",singleS,20,21). bond("31-norcycloartenol",single,20,22).
+bond("31-norcycloartenol",single,22,23). bond("31-norcycloartenol",single,23,24). bond("31-norcycloartenol",double,24,25).
+bond("31-norcycloartenol",single,25,26). bond("31-norcycloartenol",single,25,27).
+
+atom("4α,14α-dimethyl-5α-cholesta-8,24-dien-3β-ol",1..28,carb). atom("4α,14α-dimethyl-5α-cholesta-8,24-dien-3β-ol",30,carb). atom("4α,14α-dimethyl-5α-cholesta-8,24-dien-3β-ol",31,oxyg).
+bond("4α,14α-dimethyl-5α-cholesta-8,24-dien-3β-ol",single,1,2). bond("4α,14α-dimethyl-5α-cholesta-8,24-dien-3β-ol",single,1,10). bond("4α,14α-dimethyl-5α-cholesta-8,24-dien-3β-ol",single,2,3).
+bond("4α,14α-dimethyl-5α-cholesta-8,24-dien-3β-ol",single,3,4). bond("4α,14α-dimethyl-5α-cholesta-8,24-dien-3β-ol",double,3,31). bond("4α,14α-dimethyl-5α-cholesta-8,24-dien-3β-ol",single,4,5).
+bond("4α,14α-dimethyl-5α-cholesta-8,24-dien-3β-ol",singleS,4,28). bond("4α,14α-dimethyl-5α-cholesta-8,24-dien-3β-ol",single,5,6). bond("4α,14α-dimethyl-5α-cholesta-8,24-dien-3β-ol",single,5,10).
+bond("4α,14α-dimethyl-5α-cholesta-8,24-dien-3β-ol",single,6,7). bond("4α,14α-dimethyl-5α-cholesta-8,24-dien-3β-ol",single,7,8). bond("4α,14α-dimethyl-5α-cholesta-8,24-dien-3β-ol",double,8,9).
+bond("4α,14α-dimethyl-5α-cholesta-8,24-dien-3β-ol",single,8,14). bond("4α,14α-dimethyl-5α-cholesta-8,24-dien-3β-ol",single,9,10). bond("4α,14α-dimethyl-5α-cholesta-8,24-dien-3β-ol",single,9,11).
+bond("4α,14α-dimethyl-5α-cholesta-8,24-dien-3β-ol",singleR,10,19). bond("4α,14α-dimethyl-5α-cholesta-8,24-dien-3β-ol",single,11,12). bond("4α,14α-dimethyl-5α-cholesta-8,24-dien-3β-ol",single,12,13).
+bond("4α,14α-dimethyl-5α-cholesta-8,24-dien-3β-ol",single,13,14). bond("4α,14α-dimethyl-5α-cholesta-8,24-dien-3β-ol",single,14,15). bond("4α,14α-dimethyl-5α-cholesta-8,24-dien-3β-ol",single,15,16).
+bond("4α,14α-dimethyl-5α-cholesta-8,24-dien-3β-ol",single,16,17). bond("4α,14α-dimethyl-5α-cholesta-8,24-dien-3β-ol",single,13,17). bond("4α,14α-dimethyl-5α-cholesta-8,24-dien-3β-ol",singleR,13,18).
+bond("4α,14α-dimethyl-5α-cholesta-8,24-dien-3β-ol",singleR,17,20). bond("4α,14α-dimethyl-5α-cholesta-8,24-dien-3β-ol",singleS,20,21). bond("4α,14α-dimethyl-5α-cholesta-8,24-dien-3β-ol",single,20,22).
+bond("4α,14α-dimethyl-5α-cholesta-8,24-dien-3β-ol",single,22,23). bond("4α,14α-dimethyl-5α-cholesta-8,24-dien-3β-ol",single,23,24). bond("4α,14α-dimethyl-5α-cholesta-8,24-dien-3β-ol",double,24,25).
+bond("4α,14α-dimethyl-5α-cholesta-8,24-dien-3β-ol",single,25,26). bond("4α,14α-dimethyl-5α-cholesta-8,24-dien-3β-ol",single,25,27).
+
+atom("4α-hydroxymethyl-14α-methyl-5α-cholesta-8,24-dien-3β-ol",1..28,carb). atom("4α-hydroxymethyl-14α-methyl-5α-cholesta-8,24-dien-3β-ol",30,carb). atom("4α-hydroxymethyl-14α-methyl-5α-cholesta-8,24-dien-3β-ol",31,oxyg).
+atom("4α-hydroxymethyl-14α-methyl-5α-cholesta-8,24-dien-3β-ol",34,oxyg).
+bond("4α-hydroxymethyl-14α-methyl-5α-cholesta-8,24-dien-3β-ol",single,1,2). bond("4α-hydroxymethyl-14α-methyl-5α-cholesta-8,24-dien-3β-ol",single,1,10). bond("4α-hydroxymethyl-14α-methyl-5α-cholesta-8,24-dien-3β-ol",single,2,3).
+bond("4α-hydroxymethyl-14α-methyl-5α-cholesta-8,24-dien-3β-ol",single,3,4). bond("4α-hydroxymethyl-14α-methyl-5α-cholesta-8,24-dien-3β-ol",double,3,31). bond("4α-hydroxymethyl-14α-methyl-5α-cholesta-8,24-dien-3β-ol",single,4,5).
+bond("4α-hydroxymethyl-14α-methyl-5α-cholesta-8,24-dien-3β-ol",singleS,4,28). bond("4α-hydroxymethyl-14α-methyl-5α-cholesta-8,24-dien-3β-ol",single,5,6). bond("4α-hydroxymethyl-14α-methyl-5α-cholesta-8,24-dien-3β-ol",single,5,10).
+bond("4α-hydroxymethyl-14α-methyl-5α-cholesta-8,24-dien-3β-ol",single,6,7). bond("4α-hydroxymethyl-14α-methyl-5α-cholesta-8,24-dien-3β-ol",single,7,8). bond("4α-hydroxymethyl-14α-methyl-5α-cholesta-8,24-dien-3β-ol",double,8,9).
+bond("4α-hydroxymethyl-14α-methyl-5α-cholesta-8,24-dien-3β-ol",single,8,14). bond("4α-hydroxymethyl-14α-methyl-5α-cholesta-8,24-dien-3β-ol",single,9,10). bond("4α-hydroxymethyl-14α-methyl-5α-cholesta-8,24-dien-3β-ol",single,9,11).
+bond("4α-hydroxymethyl-14α-methyl-5α-cholesta-8,24-dien-3β-ol",singleR,10,19). bond("4α-hydroxymethyl-14α-methyl-5α-cholesta-8,24-dien-3β-ol",single,11,12). bond("4α-hydroxymethyl-14α-methyl-5α-cholesta-8,24-dien-3β-ol",single,12,13).
+bond("4α-hydroxymethyl-14α-methyl-5α-cholesta-8,24-dien-3β-ol",single,13,14). bond("4α-hydroxymethyl-14α-methyl-5α-cholesta-8,24-dien-3β-ol",single,14,15). bond("4α-hydroxymethyl-14α-methyl-5α-cholesta-8,24-dien-3β-ol",single,15,16).
+bond("4α-hydroxymethyl-14α-methyl-5α-cholesta-8,24-dien-3β-ol",single,16,17). bond("4α-hydroxymethyl-14α-methyl-5α-cholesta-8,24-dien-3β-ol",single,13,17). bond("4α-hydroxymethyl-14α-methyl-5α-cholesta-8,24-dien-3β-ol",singleR,13,18).
+bond("4α-hydroxymethyl-14α-methyl-5α-cholesta-8,24-dien-3β-ol",singleR,17,20). bond("4α-hydroxymethyl-14α-methyl-5α-cholesta-8,24-dien-3β-ol",singleS,20,21). bond("4α-hydroxymethyl-14α-methyl-5α-cholesta-8,24-dien-3β-ol",single,20,22).
+bond("4α-hydroxymethyl-14α-methyl-5α-cholesta-8,24-dien-3β-ol",single,22,23). bond("4α-hydroxymethyl-14α-methyl-5α-cholesta-8,24-dien-3β-ol",single,23,24). bond("4α-hydroxymethyl-14α-methyl-5α-cholesta-8,24-dien-3β-ol",double,24,25).
+bond("4α-hydroxymethyl-14α-methyl-5α-cholesta-8,24-dien-3β-ol",single,25,26). bond("4α-hydroxymethyl-14α-methyl-5α-cholesta-8,24-dien-3β-ol",single,25,27). bond("4α-hydroxymethyl-14α-methyl-5α-cholesta-8,24-dien-3β-ol",single,29,34).
+
+atom("4α-formyl-14α-methyl-5α-cholesta-8,24-dien-3β-ol",1..28,carb). atom("4α-formyl-14α-methyl-5α-cholesta-8,24-dien-3β-ol",30,carb). atom("4α-formyl-14α-methyl-5α-cholesta-8,24-dien-3β-ol",31,oxyg).
+atom("4α-formyl-14α-methyl-5α-cholesta-8,24-dien-3β-ol",34,oxyg).
+bond("4α-formyl-14α-methyl-5α-cholesta-8,24-dien-3β-ol",single,1,2). bond("4α-formyl-14α-methyl-5α-cholesta-8,24-dien-3β-ol",single,1,10). bond("4α-formyl-14α-methyl-5α-cholesta-8,24-dien-3β-ol",single,2,3).
+bond("4α-formyl-14α-methyl-5α-cholesta-8,24-dien-3β-ol",single,3,4). bond("4α-formyl-14α-methyl-5α-cholesta-8,24-dien-3β-ol",double,3,31). bond("4α-formyl-14α-methyl-5α-cholesta-8,24-dien-3β-ol",single,4,5).
+bond("4α-formyl-14α-methyl-5α-cholesta-8,24-dien-3β-ol",singleS,4,28). bond("4α-formyl-14α-methyl-5α-cholesta-8,24-dien-3β-ol",single,5,6). bond("4α-formyl-14α-methyl-5α-cholesta-8,24-dien-3β-ol",single,5,10).
+bond("4α-formyl-14α-methyl-5α-cholesta-8,24-dien-3β-ol",single,6,7). bond("4α-formyl-14α-methyl-5α-cholesta-8,24-dien-3β-ol",single,7,8). bond("4α-formyl-14α-methyl-5α-cholesta-8,24-dien-3β-ol",double,8,9).
+bond("4α-formyl-14α-methyl-5α-cholesta-8,24-dien-3β-ol",single,8,14). bond("4α-formyl-14α-methyl-5α-cholesta-8,24-dien-3β-ol",single,9,10). bond("4α-formyl-14α-methyl-5α-cholesta-8,24-dien-3β-ol",single,9,11).
+bond("4α-formyl-14α-methyl-5α-cholesta-8,24-dien-3β-ol",singleR,10,19). bond("4α-formyl-14α-methyl-5α-cholesta-8,24-dien-3β-ol",single,11,12). bond("4α-formyl-14α-methyl-5α-cholesta-8,24-dien-3β-ol",single,12,13).
+bond("4α-formyl-14α-methyl-5α-cholesta-8,24-dien-3β-ol",single,13,14). bond("4α-formyl-14α-methyl-5α-cholesta-8,24-dien-3β-ol",single,14,15). bond("4α-formyl-14α-methyl-5α-cholesta-8,24-dien-3β-ol",single,15,16).
+bond("4α-formyl-14α-methyl-5α-cholesta-8,24-dien-3β-ol",single,16,17). bond("4α-formyl-14α-methyl-5α-cholesta-8,24-dien-3β-ol",single,13,17). bond("4α-formyl-14α-methyl-5α-cholesta-8,24-dien-3β-ol",singleR,13,18).
+bond("4α-formyl-14α-methyl-5α-cholesta-8,24-dien-3β-ol",singleR,17,20). bond("4α-formyl-14α-methyl-5α-cholesta-8,24-dien-3β-ol",singleS,20,21). bond("4α-formyl-14α-methyl-5α-cholesta-8,24-dien-3β-ol",single,20,22).
+bond("4α-formyl-14α-methyl-5α-cholesta-8,24-dien-3β-ol",single,22,23). bond("4α-formyl-14α-methyl-5α-cholesta-8,24-dien-3β-ol",single,23,24). bond("4α-formyl-14α-methyl-5α-cholesta-8,24-dien-3β-ol",double,24,25).
+bond("4α-formyl-14α-methyl-5α-cholesta-8,24-dien-3β-ol",single,25,26). bond("4α-formyl-14α-methyl-5α-cholesta-8,24-dien-3β-ol",single,25,27). bond("4α-formyl-14α-methyl-5α-cholesta-8,24-dien-3β-ol",double,29,34).
+
+atom("4α-methyl-5α-cholesta-8,14,24-trien-3β-ol",1..28,carb). atom("4α-methyl-5α-cholesta-8,14,24-trien-3β-ol",31,oxyg).
+bond("4α-methyl-5α-cholesta-8,14,24-trien-3β-ol",single,1,2). bond("4α-methyl-5α-cholesta-8,14,24-trien-3β-ol",single,1,10). bond("4α-methyl-5α-cholesta-8,14,24-trien-3β-ol",single,2,3).
+bond("4α-methyl-5α-cholesta-8,14,24-trien-3β-ol",single,3,4). bond("4α-methyl-5α-cholesta-8,14,24-trien-3β-ol",double,3,31). bond("4α-methyl-5α-cholesta-8,14,24-trien-3β-ol",single,4,5).
+bond("4α-methyl-5α-cholesta-8,14,24-trien-3β-ol",singleS,4,28). bond("4α-methyl-5α-cholesta-8,14,24-trien-3β-ol",single,5,6). bond("4α-methyl-5α-cholesta-8,14,24-trien-3β-ol",single,5,10).
+bond("4α-methyl-5α-cholesta-8,14,24-trien-3β-ol",single,6,7). bond("4α-methyl-5α-cholesta-8,14,24-trien-3β-ol",single,7,8). bond("4α-methyl-5α-cholesta-8,14,24-trien-3β-ol",double,8,9).
+bond("4α-methyl-5α-cholesta-8,14,24-trien-3β-ol",single,8,14). bond("4α-methyl-5α-cholesta-8,14,24-trien-3β-ol",single,9,10). bond("4α-methyl-5α-cholesta-8,14,24-trien-3β-ol",single,9,11).
+bond("4α-methyl-5α-cholesta-8,14,24-trien-3β-ol",singleR,10,19). bond("4α-methyl-5α-cholesta-8,14,24-trien-3β-ol",single,11,12). bond("4α-methyl-5α-cholesta-8,14,24-trien-3β-ol",single,12,13).
+bond("4α-methyl-5α-cholesta-8,14,24-trien-3β-ol",single,13,14). bond("4α-methyl-5α-cholesta-8,14,24-trien-3β-ol",double,14,15). bond("4α-methyl-5α-cholesta-8,14,24-trien-3β-ol",single,15,16).
+bond("4α-methyl-5α-cholesta-8,14,24-trien-3β-ol",single,16,17). bond("4α-methyl-5α-cholesta-8,14,24-trien-3β-ol",single,13,17). bond("4α-methyl-5α-cholesta-8,14,24-trien-3β-ol",singleR,13,18).
+bond("4α-methyl-5α-cholesta-8,14,24-trien-3β-ol",singleR,17,20). bond("4α-methyl-5α-cholesta-8,14,24-trien-3β-ol",singleS,20,21). bond("4α-methyl-5α-cholesta-8,14,24-trien-3β-ol",single,20,22).
+bond("4α-methyl-5α-cholesta-8,14,24-trien-3β-ol",single,22,23). bond("4α-methyl-5α-cholesta-8,14,24-trien-3β-ol",single,23,24). bond("4α-methyl-5α-cholesta-8,14,24-trien-3β-ol",double,24,25).
+bond("4α-methyl-5α-cholesta-8,14,24-trien-3β-ol",single,25,26). bond("4α-methyl-5α-cholesta-8,14,24-trien-3β-ol",single,25,27).
+
+atom("4α-methyl-5α-cholesta-8,24-dien-3β-ol",1..28,carb). atom("4α-methyl-5α-cholesta-8,24-dien-3β-ol",31,oxyg).
+bond("4α-methyl-5α-cholesta-8,24-dien-3β-ol",single,1,2). bond("4α-methyl-5α-cholesta-8,24-dien-3β-ol",single,1,10). bond("4α-methyl-5α-cholesta-8,24-dien-3β-ol",single,2,3).
+bond("4α-methyl-5α-cholesta-8,24-dien-3β-ol",single,3,4). bond("4α-methyl-5α-cholesta-8,24-dien-3β-ol",double,3,31). bond("4α-methyl-5α-cholesta-8,24-dien-3β-ol",single,4,5).
+bond("4α-methyl-5α-cholesta-8,24-dien-3β-ol",singleS,4,28). bond("4α-methyl-5α-cholesta-8,24-dien-3β-ol",single,5,6). bond("4α-methyl-5α-cholesta-8,24-dien-3β-ol",single,5,10).
+bond("4α-methyl-5α-cholesta-8,24-dien-3β-ol",single,6,7). bond("4α-methyl-5α-cholesta-8,24-dien-3β-ol",single,7,8). bond("4α-methyl-5α-cholesta-8,24-dien-3β-ol",double,8,9).
+bond("4α-methyl-5α-cholesta-8,24-dien-3β-ol",single,8,14). bond("4α-methyl-5α-cholesta-8,24-dien-3β-ol",single,9,10). bond("4α-methyl-5α-cholesta-8,24-dien-3β-ol",single,9,11).
+bond("4α-methyl-5α-cholesta-8,24-dien-3β-ol",singleR,10,19). bond("4α-methyl-5α-cholesta-8,24-dien-3β-ol",single,11,12). bond("4α-methyl-5α-cholesta-8,24-dien-3β-ol",single,12,13).
+bond("4α-methyl-5α-cholesta-8,24-dien-3β-ol",single,13,14). bond("4α-methyl-5α-cholesta-8,24-dien-3β-ol",single,14,15). bond("4α-methyl-5α-cholesta-8,24-dien-3β-ol",single,15,16).
+bond("4α-methyl-5α-cholesta-8,24-dien-3β-ol",single,16,17). bond("4α-methyl-5α-cholesta-8,24-dien-3β-ol",single,13,17). bond("4α-methyl-5α-cholesta-8,24-dien-3β-ol",singleR,13,18).
+bond("4α-methyl-5α-cholesta-8,24-dien-3β-ol",singleR,17,20). bond("4α-methyl-5α-cholesta-8,24-dien-3β-ol",singleS,20,21). bond("4α-methyl-5α-cholesta-8,24-dien-3β-ol",single,20,22).
+bond("4α-methyl-5α-cholesta-8,24-dien-3β-ol",single,22,23). bond("4α-methyl-5α-cholesta-8,24-dien-3β-ol",single,23,24). bond("4α-methyl-5α-cholesta-8,24-dien-3β-ol",double,24,25).
+bond("4α-methyl-5α-cholesta-8,24-dien-3β-ol",single,25,26). bond("4α-methyl-5α-cholesta-8,24-dien-3β-ol",single,25,27).
+
+atom("4α-methyl-5α-cholesta-7,24-dien-3β-ol",1..28,carb). atom("4α-methyl-5α-cholesta-7,24-dien-3β-ol",31,oxyg).
+bond("4α-methyl-5α-cholesta-7,24-dien-3β-ol",single,1,2). bond("4α-methyl-5α-cholesta-7,24-dien-3β-ol",single,1,10). bond("4α-methyl-5α-cholesta-7,24-dien-3β-ol",single,2,3).
+bond("4α-methyl-5α-cholesta-7,24-dien-3β-ol",single,3,4). bond("4α-methyl-5α-cholesta-7,24-dien-3β-ol",double,3,31). bond("4α-methyl-5α-cholesta-7,24-dien-3β-ol",single,4,5).
+bond("4α-methyl-5α-cholesta-7,24-dien-3β-ol",singleS,4,28). bond("4α-methyl-5α-cholesta-7,24-dien-3β-ol",single,5,6). bond("4α-methyl-5α-cholesta-7,24-dien-3β-ol",single,5,10).
+bond("4α-methyl-5α-cholesta-7,24-dien-3β-ol",single,6,7). bond("4α-methyl-5α-cholesta-7,24-dien-3β-ol",double,7,8). bond("4α-methyl-5α-cholesta-7,24-dien-3β-ol",single,8,9).
+bond("4α-methyl-5α-cholesta-7,24-dien-3β-ol",single,8,14). bond("4α-methyl-5α-cholesta-7,24-dien-3β-ol",single,9,10). bond("4α-methyl-5α-cholesta-7,24-dien-3β-ol",single,9,11).
+bond("4α-methyl-5α-cholesta-7,24-dien-3β-ol",singleR,10,19). bond("4α-methyl-5α-cholesta-7,24-dien-3β-ol",single,11,12). bond("4α-methyl-5α-cholesta-7,24-dien-3β-ol",single,12,13).
+bond("4α-methyl-5α-cholesta-7,24-dien-3β-ol",single,13,14). bond("4α-methyl-5α-cholesta-7,24-dien-3β-ol",single,14,15). bond("4α-methyl-5α-cholesta-7,24-dien-3β-ol",single,15,16).
+bond("4α-methyl-5α-cholesta-7,24-dien-3β-ol",single,16,17). bond("4α-methyl-5α-cholesta-7,24-dien-3β-ol",single,13,17). bond("4α-methyl-5α-cholesta-7,24-dien-3β-ol",singleR,13,18).
+bond("4α-methyl-5α-cholesta-7,24-dien-3β-ol",singleR,17,20). bond("4α-methyl-5α-cholesta-7,24-dien-3β-ol",singleS,20,21). bond("4α-methyl-5α-cholesta-7,24-dien-3β-ol",single,20,22).
+bond("4α-methyl-5α-cholesta-7,24-dien-3β-ol",single,22,23). bond("4α-methyl-5α-cholesta-7,24-dien-3β-ol",single,23,24). bond("4α-methyl-5α-cholesta-7,24-dien-3β-ol",double,24,25).
+bond("4α-methyl-5α-cholesta-7,24-dien-3β-ol",single,25,26). bond("4α-methyl-5α-cholesta-7,24-dien-3β-ol",single,25,27).
+
+atom("4α-methylhydroxy-5α-cholest-7,24-dien-3β-ol",1..28,carb). atom("4α-methylhydroxy-5α-cholest-7,24-dien-3β-ol",31,oxyg). atom("4α-methylhydroxy-5α-cholest-7,24-dien-3β-ol",34,oxyg).
+bond("4α-methylhydroxy-5α-cholest-7,24-dien-3β-ol",single,1,2). bond("4α-methylhydroxy-5α-cholest-7,24-dien-3β-ol",single,1,10). bond("4α-methylhydroxy-5α-cholest-7,24-dien-3β-ol",single,2,3).
+bond("4α-methylhydroxy-5α-cholest-7,24-dien-3β-ol",single,3,4). bond("4α-methylhydroxy-5α-cholest-7,24-dien-3β-ol",double,3,31). bond("4α-methylhydroxy-5α-cholest-7,24-dien-3β-ol",single,4,5).
+bond("4α-methylhydroxy-5α-cholest-7,24-dien-3β-ol",singleS,4,28). bond("4α-methylhydroxy-5α-cholest-7,24-dien-3β-ol",single,5,6). bond("4α-methylhydroxy-5α-cholest-7,24-dien-3β-ol",single,5,10).
+bond("4α-methylhydroxy-5α-cholest-7,24-dien-3β-ol",single,6,7). bond("4α-methylhydroxy-5α-cholest-7,24-dien-3β-ol",double,7,8). bond("4α-methylhydroxy-5α-cholest-7,24-dien-3β-ol",single,8,9).
+bond("4α-methylhydroxy-5α-cholest-7,24-dien-3β-ol",single,8,14). bond("4α-methylhydroxy-5α-cholest-7,24-dien-3β-ol",single,9,10). bond("4α-methylhydroxy-5α-cholest-7,24-dien-3β-ol",single,9,11).
+bond("4α-methylhydroxy-5α-cholest-7,24-dien-3β-ol",singleR,10,19). bond("4α-methylhydroxy-5α-cholest-7,24-dien-3β-ol",single,11,12). bond("4α-methylhydroxy-5α-cholest-7,24-dien-3β-ol",single,12,13).
+bond("4α-methylhydroxy-5α-cholest-7,24-dien-3β-ol",single,13,14). bond("4α-methylhydroxy-5α-cholest-7,24-dien-3β-ol",single,14,15). bond("4α-methylhydroxy-5α-cholest-7,24-dien-3β-ol",single,15,16).
+bond("4α-methylhydroxy-5α-cholest-7,24-dien-3β-ol",single,16,17). bond("4α-methylhydroxy-5α-cholest-7,24-dien-3β-ol",single,13,17). bond("4α-methylhydroxy-5α-cholest-7,24-dien-3β-ol",singleR,13,18).
+bond("4α-methylhydroxy-5α-cholest-7,24-dien-3β-ol",singleR,17,20). bond("4α-methylhydroxy-5α-cholest-7,24-dien-3β-ol",singleS,20,21). bond("4α-methylhydroxy-5α-cholest-7,24-dien-3β-ol",single,20,22).
+bond("4α-methylhydroxy-5α-cholest-7,24-dien-3β-ol",single,22,23). bond("4α-methylhydroxy-5α-cholest-7,24-dien-3β-ol",single,23,24). bond("4α-methylhydroxy-5α-cholest-7,24-dien-3β-ol",double,24,25).
+bond("4α-methylhydroxy-5α-cholest-7,24-dien-3β-ol",single,25,26). bond("4α-methylhydroxy-5α-cholest-7,24-dien-3β-ol",single,25,27). bond("4α-methylhydroxy-5α-cholest-7,24-dien-3β-ol",single,29,34).
+
+atom("4α-formyl-5α-cholest-7,24-dien-3β-ol",1..28,carb). atom("4α-formyl-5α-cholest-7,24-dien-3β-ol",31,oxyg). atom("4α-formyl-5α-cholest-7,24-dien-3β-ol",34,oxyg).
+bond("4α-formyl-5α-cholest-7,24-dien-3β-ol",single,1,2). bond("4α-formyl-5α-cholest-7,24-dien-3β-ol",single,1,10). bond("4α-formyl-5α-cholest-7,24-dien-3β-ol",single,2,3).
+bond("4α-formyl-5α-cholest-7,24-dien-3β-ol",single,3,4). bond("4α-formyl-5α-cholest-7,24-dien-3β-ol",double,3,31). bond("4α-formyl-5α-cholest-7,24-dien-3β-ol",single,4,5).
+bond("4α-formyl-5α-cholest-7,24-dien-3β-ol",singleS,4,28). bond("4α-formyl-5α-cholest-7,24-dien-3β-ol",single,5,6). bond("4α-formyl-5α-cholest-7,24-dien-3β-ol",single,5,10).
+bond("4α-formyl-5α-cholest-7,24-dien-3β-ol",single,6,7). bond("4α-formyl-5α-cholest-7,24-dien-3β-ol",double,7,8). bond("4α-formyl-5α-cholest-7,24-dien-3β-ol",single,8,9).
+bond("4α-formyl-5α-cholest-7,24-dien-3β-ol",single,8,14). bond("4α-formyl-5α-cholest-7,24-dien-3β-ol",single,9,10). bond("4α-formyl-5α-cholest-7,24-dien-3β-ol",single,9,11).
+bond("4α-formyl-5α-cholest-7,24-dien-3β-ol",singleR,10,19). bond("4α-formyl-5α-cholest-7,24-dien-3β-ol",single,11,12). bond("4α-formyl-5α-cholest-7,24-dien-3β-ol",single,12,13).
+bond("4α-formyl-5α-cholest-7,24-dien-3β-ol",single,13,14). bond("4α-formyl-5α-cholest-7,24-dien-3β-ol",single,14,15). bond("4α-formyl-5α-cholest-7,24-dien-3β-ol",single,15,16).
+bond("4α-formyl-5α-cholest-7,24-dien-3β-ol",single,16,17). bond("4α-formyl-5α-cholest-7,24-dien-3β-ol",single,13,17). bond("4α-formyl-5α-cholest-7,24-dien-3β-ol",singleR,13,18).
+bond("4α-formyl-5α-cholest-7,24-dien-3β-ol",singleR,17,20). bond("4α-formyl-5α-cholest-7,24-dien-3β-ol",singleS,20,21). bond("4α-formyl-5α-cholest-7,24-dien-3β-ol",single,20,22).
+bond("4α-formyl-5α-cholest-7,24-dien-3β-ol",single,22,23). bond("4α-formyl-5α-cholest-7,24-dien-3β-ol",single,23,24). bond("4α-formyl-5α-cholest-7,24-dien-3β-ol",double,24,25).
+bond("4α-formyl-5α-cholest-7,24-dien-3β-ol",single,25,26). bond("4α-formyl-5α-cholest-7,24-dien-3β-ol",single,25,27). bond("4α-formyl-5α-cholest-7,24-dien-3β-ol",double,29,34).
+
+atom("4α-carboxy-5α-cholesta-7,24-dien-3β-ol",1..28,carb). atom("4α-carboxy-5α-cholesta-7,24-dien-3β-ol",31,oxyg). atom("4α-carboxy-5α-cholesta-7,24-dien-3β-ol",34..35,oxyg).
+bond("4α-carboxy-5α-cholesta-7,24-dien-3β-ol",single,1,2). bond("4α-carboxy-5α-cholesta-7,24-dien-3β-ol",single,1,10). bond("4α-carboxy-5α-cholesta-7,24-dien-3β-ol",single,2,3).
+bond("4α-carboxy-5α-cholesta-7,24-dien-3β-ol",single,3,4). bond("4α-carboxy-5α-cholesta-7,24-dien-3β-ol",double,3,31). bond("4α-carboxy-5α-cholesta-7,24-dien-3β-ol",single,4,5).
+bond("4α-carboxy-5α-cholesta-7,24-dien-3β-ol",singleS,4,28). bond("4α-carboxy-5α-cholesta-7,24-dien-3β-ol",single,5,6). bond("4α-carboxy-5α-cholesta-7,24-dien-3β-ol",single,5,10).
+bond("4α-carboxy-5α-cholesta-7,24-dien-3β-ol",single,6,7). bond("4α-carboxy-5α-cholesta-7,24-dien-3β-ol",double,7,8). bond("4α-carboxy-5α-cholesta-7,24-dien-3β-ol",single,8,9).
+bond("4α-carboxy-5α-cholesta-7,24-dien-3β-ol",single,8,14). bond("4α-carboxy-5α-cholesta-7,24-dien-3β-ol",single,9,10). bond("4α-carboxy-5α-cholesta-7,24-dien-3β-ol",single,9,11).
+bond("4α-carboxy-5α-cholesta-7,24-dien-3β-ol",singleR,10,19). bond("4α-carboxy-5α-cholesta-7,24-dien-3β-ol",single,11,12). bond("4α-carboxy-5α-cholesta-7,24-dien-3β-ol",single,12,13).
+bond("4α-carboxy-5α-cholesta-7,24-dien-3β-ol",single,13,14). bond("4α-carboxy-5α-cholesta-7,24-dien-3β-ol",single,14,15). bond("4α-carboxy-5α-cholesta-7,24-dien-3β-ol",single,15,16).
+bond("4α-carboxy-5α-cholesta-7,24-dien-3β-ol",single,16,17). bond("4α-carboxy-5α-cholesta-7,24-dien-3β-ol",single,13,17). bond("4α-carboxy-5α-cholesta-7,24-dien-3β-ol",singleR,13,18).
+bond("4α-carboxy-5α-cholesta-7,24-dien-3β-ol",singleR,17,20). bond("4α-carboxy-5α-cholesta-7,24-dien-3β-ol",singleS,20,21). bond("4α-carboxy-5α-cholesta-7,24-dien-3β-ol",single,20,22).
+bond("4α-carboxy-5α-cholesta-7,24-dien-3β-ol",single,22,23). bond("4α-carboxy-5α-cholesta-7,24-dien-3β-ol",single,23,24). bond("4α-carboxy-5α-cholesta-7,24-dien-3β-ol",double,24,25).
+bond("4α-carboxy-5α-cholesta-7,24-dien-3β-ol",single,25,26). bond("4α-carboxy-5α-cholesta-7,24-dien-3β-ol",single,25,27).bond("4α-carboxy-5α-cholesta-7,24-dien-3β-ol",double,29,34).
+bond("4α-carboxy-5α-cholesta-7,24-dien-3β-ol",single,29,35).
+
+atom("5α-cholesta-7,24-dien-3-one",1..27,carb). atom("5α-cholesta-7,24-dien-3-one",31,oxyg).
+bond("5α-cholesta-7,24-dien-3-one",single,1,2). bond("5α-cholesta-7,24-dien-3-one",single,1,10). bond("5α-cholesta-7,24-dien-3-one",single,2,3).
+bond("5α-cholesta-7,24-dien-3-one",single,3,4). bond("5α-cholesta-7,24-dien-3-one",double,3,31). bond("5α-cholesta-7,24-dien-3-one",single,4,5).
+bond("5α-cholesta-7,24-dien-3-one",single,5,6). bond("5α-cholesta-7,24-dien-3-one",single,5,10). bond("5α-cholesta-7,24-dien-3-one",single,6,7).
+bond("5α-cholesta-7,24-dien-3-one",double,7,8). bond("5α-cholesta-7,24-dien-3-one",single,8,9). bond("5α-cholesta-7,24-dien-3-one",single,8,14).
+bond("5α-cholesta-7,24-dien-3-one",single,9,10). bond("5α-cholesta-7,24-dien-3-one",single,9,11). bond("5α-cholesta-7,24-dien-3-one",singleR,10,19).
+bond("5α-cholesta-7,24-dien-3-one",single,11,12). bond("5α-cholesta-7,24-dien-3-one",single,12,13). bond("5α-cholesta-7,24-dien-3-one",single,13,14).
+bond("5α-cholesta-7,24-dien-3-one",single,14,15). bond("5α-cholesta-7,24-dien-3-one",single,15,16). bond("5α-cholesta-7,24-dien-3-one",single,16,17).
+bond("5α-cholesta-7,24-dien-3-one",single,13,17). bond("5α-cholesta-7,24-dien-3-one",singleR,13,18). bond("5α-cholesta-7,24-dien-3-one",singleR,17,20).
+bond("5α-cholesta-7,24-dien-3-one",singleS,20,21). bond("5α-cholesta-7,24-dien-3-one",single,20,22). bond("5α-cholesta-7,24-dien-3-one",single,22,23).
+bond("5α-cholesta-7,24-dien-3-one",single,23,24). bond("5α-cholesta-7,24-dien-3-one",double,24,25). bond("5α-cholesta-7,24-dien-3-one",single,25,26).
+bond("5α-cholesta-7,24-dien-3-one",single,25,27).
+
+atom("5α-cholesta-7,24-dienol",1..27,carb). atom("5α-cholesta-7,24-dienol",31,oxyg).
+bond("5α-cholesta-7,24-dienol",single,1,2). bond("5α-cholesta-7,24-dienol",single,1,10). bond("5α-cholesta-7,24-dienol",single,2,3).
+bond("5α-cholesta-7,24-dienol",single,3,4). bond("5α-cholesta-7,24-dienol",singleR,3,31). bond("5α-cholesta-7,24-dienol",single,4,5).
+bond("5α-cholesta-7,24-dienol",single,5,6). bond("5α-cholesta-7,24-dienol",single,5,10). bond("5α-cholesta-7,24-dienol",single,6,7).
+bond("5α-cholesta-7,24-dienol",double,7,8). bond("5α-cholesta-7,24-dienol",single,8,9). bond("5α-cholesta-7,24-dienol",single,8,14).
+bond("5α-cholesta-7,24-dienol",single,9,10). bond("5α-cholesta-7,24-dienol",single,9,11). bond("5α-cholesta-7,24-dienol",singleR,10,19).
+bond("5α-cholesta-7,24-dienol",single,11,12). bond("5α-cholesta-7,24-dienol",single,12,13). bond("5α-cholesta-7,24-dienol",single,13,14).
+bond("5α-cholesta-7,24-dienol",single,14,15). bond("5α-cholesta-7,24-dienol",single,15,16). bond("5α-cholesta-7,24-dienol",single,16,17).
+bond("5α-cholesta-7,24-dienol",single,13,17). bond("5α-cholesta-7,24-dienol",singleR,13,18). bond("5α-cholesta-7,24-dienol",singleR,17,20).
+bond("5α-cholesta-7,24-dienol",singleS,20,21). bond("5α-cholesta-7,24-dienol",single,20,22). bond("5α-cholesta-7,24-dienol",single,22,23).
+bond("5α-cholesta-7,24-dienol",single,23,24). bond("5α-cholesta-7,24-dienol",double,24,25). bond("5α-cholesta-7,24-dienol",single,25,26).
+bond("5α-cholesta-7,24-dienol",single,25,27).
+
+atom("7-dehydrodesmosterol",1..27,carb). atom("7-dehydrodesmosterol",31,oxyg).
+bond("7-dehydrodesmosterol",single,1,2). bond("7-dehydrodesmosterol",single,1,10). bond("7-dehydrodesmosterol",single,2,3).
+bond("7-dehydrodesmosterol",single,3,4). bond("7-dehydrodesmosterol",singleR,3,31). bond("7-dehydrodesmosterol",single,4,5).
+bond("7-dehydrodesmosterol",double,5,6). bond("7-dehydrodesmosterol",single,5,10). bond("7-dehydrodesmosterol",single,6,7).
+bond("7-dehydrodesmosterol",double,7,8). bond("7-dehydrodesmosterol",single,8,9). bond("7-dehydrodesmosterol",single,8,14).
+bond("7-dehydrodesmosterol",single,9,10). bond("7-dehydrodesmosterol",single,9,11). bond("7-dehydrodesmosterol",singleR,10,19).
+bond("7-dehydrodesmosterol",single,11,12). bond("7-dehydrodesmosterol",single,12,13). bond("7-dehydrodesmosterol",single,13,14).
+bond("7-dehydrodesmosterol",single,14,15). bond("7-dehydrodesmosterol",single,15,16). bond("7-dehydrodesmosterol",single,16,17).
+bond("7-dehydrodesmosterol",single,13,17). bond("7-dehydrodesmosterol",singleR,13,18). bond("7-dehydrodesmosterol",singleR,17,20).
+bond("7-dehydrodesmosterol",singleS,20,21). bond("7-dehydrodesmosterol",single,20,22). bond("7-dehydrodesmosterol",single,22,23).
+bond("7-dehydrodesmosterol",single,23,24). bond("7-dehydrodesmosterol",double,24,25). bond("7-dehydrodesmosterol",single,25,26).
+bond("7-dehydrodesmosterol",single,25,27).
+
 atom("desmosterol",1..27,carb). atom("desmosterol",31,oxyg).
 bond("desmosterol",single,1,2). bond("desmosterol",single,1,10). bond("desmosterol",single,2,3).
 bond("desmosterol",single,3,4). bond("desmosterol",singleR,3,31). bond("desmosterol",single,4,5).
@@ -120,9 +292,8 @@ bond("androst-4-ene-3,17-dione",single,5,6). bond("androst-4-ene-3,17-dione",sin
 bond("androst-4-ene-3,17-dione",single,7,8). bond("androst-4-ene-3,17-dione",single,8,9). bond("androst-4-ene-3,17-dione",single,8,14).
 bond("androst-4-ene-3,17-dione",single,9,10). bond("androst-4-ene-3,17-dione",single,9,11). ond("androst-4-ene-3,17-dione",singleR,10,19).
 bond("androst-4-ene-3,17-dione",single,11,12). bond("androst-4-ene-3,17-dione",single,12,13). bond("androst-4-ene-3,17-dione",single,13,14).
-bond("androst-4-ene-3,17-dione",single,14,15). bond("androst-4-ene-3,17-dione",singleS,14,30). bond("androst-4-ene-3,17-dione",single,15,16).
-bond("androst-4-ene-3,17-dione",single,16,17). bond("androst-4-ene-3,17-dione",single,13,17). bond("androst-4-ene-3,17-dione",singleR,13,18).
-bond("androst-4-ene-3,17-dione",double,17,20).
+bond("androst-4-ene-3,17-dione",single,14,15). bond("androst-4-ene-3,17-dione",single,15,16). bond("androst-4-ene-3,17-dione",single,16,17).
+bond("androst-4-ene-3,17-dione",single,13,17). bond("androst-4-ene-3,17-dione",singleR,13,18). bond("androst-4-ene-3,17-dione",double,17,20).
 
 atom("androsta-1,4-diene-3,17-dione",1..19,carb). atom("androsta-1,4-diene-3,17-dione",20,oxyg). atom("androsta-1,4-diene-3,17-dione",31,oxyg).
 bond("androsta-1,4-diene-3,17-dione",double,1,2). bond("androsta-1,4-diene-3,17-dione",single,1,10). bond("androsta-1,4-diene-3,17-dione",single,2,3).
@@ -131,9 +302,8 @@ bond("androsta-1,4-diene-3,17-dione",single,5,6). bond("androsta-1,4-diene-3,17-
 bond("androsta-1,4-diene-3,17-dione",single,7,8). bond("androsta-1,4-diene-3,17-dione",single,8,9). bond("androsta-1,4-diene-3,17-dione",single,8,14).
 bond("androsta-1,4-diene-3,17-dione",single,9,10). bond("androsta-1,4-diene-3,17-dione",single,9,11). ond("androsta-1,4-diene-3,17-dione",singleR,10,19).
 bond("androsta-1,4-diene-3,17-dione",single,11,12). bond("androsta-1,4-diene-3,17-dione",single,12,13). bond("androsta-1,4-diene-3,17-dione",single,13,14).
-bond("androsta-1,4-diene-3,17-dione",single,14,15). bond("androsta-1,4-diene-3,17-dione",singleS,14,30). bond("androsta-1,4-diene-3,17-dione",single,15,16).
-bond("androsta-1,4-diene-3,17-dione",single,16,17). bond("androsta-1,4-diene-3,17-dione",single,13,17). bond("androsta-1,4-diene-3,17-dione",singleR,13,18).
-bond("androsta-1,4-diene-3,17-dione",double,17,20).
+bond("androsta-1,4-diene-3,17-dione",single,13,17). bond("androsta-1,4-diene-3,17-dione",singleR,13,18). bond("androsta-1,4-diene-3,17-dione",single,14,15).
+bond("androsta-1,4-diene-3,17-dione",single,15,16). bond("androsta-1,4-diene-3,17-dione",single,16,17). bond("androsta-1,4-diene-3,17-dione",double,17,20).
 
 % Information necessary to infer new 23 hydroxylation
 atom("(22α)-hydroxy-campest-4-en-3-one",1..27,carb).  atom("(22α)-hydroxy-campest-4-en-3-one",30,carb). atom("(22α)-hydroxy-campest-4-en-3-one",31,oxyg).
@@ -261,6 +431,21 @@ reaction(rxn_21827, "(3β,9β)-4α-demethyl-4α-methylhydroxy-9,19-cyclolanost-2
 reaction(rxn_21828, "(3β,9β)-4α-demethyl-4α-formyl-9,19-cyclolanost-24-en-3-ol", "(3β,9β)-4α-demethyl-4α-carboxy-9,19-cyclolanost-24-en-3-ol").
 reaction(rxn_21830, "(3β,9β)-4α-demethyl-4α-carboxy-9,19-cyclolanost-24-en-3-ol", "31-norcycloartenone").
 
+reaction(rxn_21831, "31-norcycloartenone", "31-norcycloartenol").
+reaction(rxn_11876, "31-norcycloartenol", "4α,14α-dimethyl-5α-cholesta-8,24-dien-3β-ol").
+reaction(rxn_21165, "4α,14α-dimethyl-5α-cholesta-8,24-dien-3β-ol", "4α-hydroxymethyl-14α-methyl-5α-cholesta-8,24-dien-3β-ol").
+reaction(rxn_21166, "4α-hydroxymethyl-14α-methyl-5α-cholesta-8,24-dien-3β-ol", "4α-formyl-14α-methyl-5α-cholesta-8,24-dien-3β-ol").
+reaction(rxn_21167, "4α-formyl-14α-methyl-5α-cholesta-8,24-dien-3β-ol", "4α-methyl-5α-cholesta-8,14,24-trien-3β-ol").
+reaction(rxn_11878, "4α-methyl-5α-cholesta-8,14,24-trien-3β-ol", "4α-methyl-5α-cholesta-8,24-dien-3β-ol").
+reaction(rxn_11884, "4α-methyl-5α-cholesta-8,24-dien-3β-ol", "4α-methyl-5α-cholesta-7,24-dien-3β-ol").
+reaction(rxn_21833, "4α-methyl-5α-cholesta-7,24-dien-3β-ol", "4α-methylhydroxy-5α-cholest-7,24-dien-3β-ol").
+reaction(rxn_21834, "4α-methylhydroxy-5α-cholest-7,24-dien-3β-ol", "4α-formyl-5α-cholest-7,24-dien-3β-ol").
+reaction(rxn_21835, "4α-formyl-5α-cholest-7,24-dien-3β-ol", "4α-carboxy-5α-cholesta-7,24-dien-3β-ol").
+reaction(rxn_11959, "4α-carboxy-5α-cholesta-7,24-dien-3β-ol", "5α-cholesta-7,24-dien-3-one").
+
+reaction(rxn_21837, "5α-cholesta-7,24-dien-3-one", "5α-cholesta-7,24-dienol").
+reaction(rxn_11887, "5α-cholesta-7,24-dienol", "7-dehydrodesmosterol").
+reaction(rxn66_27, "7-dehydrodesmosterol", "desmosterol").
 % PWY66-4 and PWY-8191
 reaction(rxn66_28, "desmosterol", "cholesterol").
 

--- a/pathmodel/data/mozukulins_pwy.lp
+++ b/pathmodel/data/mozukulins_pwy.lp
@@ -1,4 +1,4 @@
-%*This is work in progress for a paper by Girard et al., to be submitted to Frontiers in Plant Science, and has not yet been peer reviewed. 
+%*This file correspond to the encoding of the data shown in Fig 3 from a paper by Girard et al., for which revision are being finalized for Frontiers in Plant Science. 
 *%
 
 
@@ -633,7 +633,7 @@ reaction(rxn66_27, "7-dehydrodesmosterol", "desmosterol").
 % PWY66-4 and PWY-8191
 reaction(rxn66_28, "desmosterol", "cholesterol").
 
-% Information necessary to infer new Δ1-2 reduction
+% Information necessary to infer new Δ1-2 desaturation
 % PWY-6944: androstenedione degradation I (aerobic)
 reaction(rxn_12714, "androst-4-ene-3,17-dione", "androsta-1,4-diene-3,17-dione").
 % corresponding metacyc general reactions (EC 1.3.99.4)
@@ -690,7 +690,7 @@ goal(pathway("cycloartenol","mozukulin B")).
 
 %* Expected inferred reactions: 
 
-reaction(delta1_2_ketoreduction,31-norcycloartenone,"Δ1-2,31-norcycloartenone").
+reaction(delta1_2_desaturation,31-norcycloartenone,"Δ1-2,31-norcycloartenone").
 reaction(23-hydroxylation, "Δ1-2,31-norcycloartenone", "23-hydroxy-Δ1-2-31-norcycloartenone").
 reaction(23_hydroxysteroid_reduction, "23-hydroxy-Δ1-2-31-norcycloartenone", "mozukulin A").
 reaction(delta24reduction, "mozukulin A", "mozukulin B"). 

--- a/pathmodel/data/mozukulins_pwy.lp
+++ b/pathmodel/data/mozukulins_pwy.lp
@@ -327,6 +327,153 @@ bond("androsta-1,4-diene-3,17-dione",single,11,12). bond("androsta-1,4-diene-3,1
 bond("androsta-1,4-diene-3,17-dione",single,13,17). bond("androsta-1,4-diene-3,17-dione",singleR,13,18). bond("androsta-1,4-diene-3,17-dione",single,14,15).
 bond("androsta-1,4-diene-3,17-dione",single,15,16). bond("androsta-1,4-diene-3,17-dione",single,16,17). bond("androsta-1,4-diene-3,17-dione",double,17,20).
 
+%
+
+atom("campesterol",1..27,carb).  atom("campesterol",30,carb). atom("campesterol",31,oxyg).
+atom("campesterol",35,carb).
+bond("campesterol",single,1,2). bond("campesterol",single,1,10). bond("campesterol",single,2,3).
+bond("campesterol",single,3,4). bond("campesterol",singleR,3,31). bond("campesterol",single,4,5).
+bond("campesterol",double,5,6). bond("campesterol",single,5,10). bond("campesterol",single,6,7).
+bond("campesterol",single,7,8). bond("campesterol",single,8,9). bond("campesterol",single,8,14).
+bond("campesterol",single,9,10). bond("campesterol",single,9,11). bond("campesterol",singleR,10,19).
+bond("campesterol",single,11,12). bond("campesterol",single,12,13). bond("campesterol",single,13,14).
+bond("campesterol",single,14,15). bond("campesterol",singleS,14,30). bond("campesterol",single,15,16).
+bond("campesterol",single,16,17). bond("campesterol",single,13,17). bond("campesterol",singleR,13,18).
+bond("campesterol",singleR,17,20). bond("campesterol",singleS,20,21). bond("campesterol",single,20,22).
+bond("campesterol",single,22,23). bond("campesterol",single,23,24). bond("campesterol",single,24,25).
+bond("campesterol",singleR,24,35). bond("campesterol",single,25,26). bond("campesterol",single,25,27).
+
+atom("(22α)-hydroxy-campesterol",1..27,carb).  atom("(22α)-hydroxy-campesterol",30,carb). atom("(22α)-hydroxy-campesterol",31,oxyg).
+atom("(22α)-hydroxy-campesterol",34,oxyg). atom("(22α)-hydroxy-campesterol",35,carb).
+bond("(22α)-hydroxy-campesterol",single,1,2). bond("(22α)-hydroxy-campesterol",single,1,10). bond("(22α)-hydroxy-campesterol",single,2,3).
+bond("(22α)-hydroxy-campesterol",single,3,4). bond("(22α)-hydroxy-campesterol",singleR,3,31). bond("(22α)-hydroxy-campesterol",single,4,5).
+bond("(22α)-hydroxy-campesterol",double,5,6). bond("(22α)-hydroxy-campesterol",single,5,10). bond("(22α)-hydroxy-campesterol",single,6,7).
+bond("(22α)-hydroxy-campesterol",single,7,8). bond("(22α)-hydroxy-campesterol",single,8,9). bond("(22α)-hydroxy-campesterol",single,8,14).
+bond("(22α)-hydroxy-campesterol",single,9,10). bond("(22α)-hydroxy-campesterol",single,9,11). bond("(22α)-hydroxy-campesterol",singleR,10,19).
+bond("(22α)-hydroxy-campesterol",single,11,12). bond("(22α)-hydroxy-campesterol",single,12,13). bond("(22α)-hydroxy-campesterol",single,13,14).
+bond("(22α)-hydroxy-campesterol",single,14,15). bond("(22α)-hydroxy-campesterol",singleS,14,30). bond("(22α)-hydroxy-campesterol",single,15,16).
+bond("(22α)-hydroxy-campesterol",single,16,17). bond("(22α)-hydroxy-campesterol",single,13,17). bond("(22α)-hydroxy-campesterol",singleR,13,18).
+bond("(22α)-hydroxy-campesterol",singleR,17,20). bond("(22α)-hydroxy-campesterol",singleS,20,21). bond("(22α)-hydroxy-campesterol",single,20,22).
+bond("(22α)-hydroxy-campesterol",singleR,22,34). bond("(22α)-hydroxy-campesterol",single,22,23). bond("(22α)-hydroxy-campesterol",single,23,24).
+bond("(22α)-hydroxy-campesterol",single,24,25). bond("(22α)-hydroxy-campesterol",singleR,24,35). bond("(22α)-hydroxy-campesterol",single,25,26).
+bond("(22α)-hydroxy-campesterol",single,25,27).
+
+atom("(22R,23R)-22,23-dihydroxycampesterol",1..27,carb).  atom("(22R,23R)-22,23-dihydroxycampesterol",30,carb). atom("(22R,23R)-22,23-dihydroxycampesterol",31,oxyg).
+atom("(22R,23R)-22,23-dihydroxycampesterol",32,oxyg). atom("(22R,23R)-22,23-dihydroxycampesterol",34,oxyg). atom("(22R,23R)-22,23-dihydroxycampesterol",35,carb).
+bond("(22R,23R)-22,23-dihydroxycampesterol",single,1,2). bond("(22R,23R)-22,23-dihydroxycampesterol",single,1,10). bond("(22R,23R)-22,23-dihydroxycampesterol",single,2,3).
+bond("(22R,23R)-22,23-dihydroxycampesterol",single,3,4). bond("(22R,23R)-22,23-dihydroxycampesterol",singleR,3,31). bond("(22R,23R)-22,23-dihydroxycampesterol",single,4,5).
+bond("(22R,23R)-22,23-dihydroxycampesterol",double,5,6). bond("(22R,23R)-22,23-dihydroxycampesterol",single,5,10). bond("(22R,23R)-22,23-dihydroxycampesterol",single,6,7).
+bond("(22R,23R)-22,23-dihydroxycampesterol",single,7,8). bond("(22R,23R)-22,23-dihydroxycampesterol",single,8,9). bond("(22R,23R)-22,23-dihydroxycampesterol",single,8,14).
+bond("(22R,23R)-22,23-dihydroxycampesterol",single,9,10). bond("(22R,23R)-22,23-dihydroxycampesterol",single,9,11). bond("(22R,23R)-22,23-dihydroxycampesterol",singleR,10,19).
+bond("(22R,23R)-22,23-dihydroxycampesterol",single,11,12). bond("(22R,23R)-22,23-dihydroxycampesterol",single,12,13). bond("(22R,23R)-22,23-dihydroxycampesterol",single,13,14).
+bond("(22R,23R)-22,23-dihydroxycampesterol",single,14,15). bond("(22R,23R)-22,23-dihydroxycampesterol",singleS,14,30). bond("(22R,23R)-22,23-dihydroxycampesterol",single,15,16).
+bond("(22R,23R)-22,23-dihydroxycampesterol",single,16,17). bond("(22R,23R)-22,23-dihydroxycampesterol",single,13,17). bond("(22R,23R)-22,23-dihydroxycampesterol",singleR,13,18).
+bond("(22R,23R)-22,23-dihydroxycampesterol",singleR,17,20). bond("(22R,23R)-22,23-dihydroxycampesterol",singleS,20,21). bond("(22R,23R)-22,23-dihydroxycampesterol",single,20,22).
+bond("(22R,23R)-22,23-dihydroxycampesterol",singleR,22,34). bond("(22R,23R)-22,23-dihydroxycampesterol",single,22,23). bond("(22R,23R)-22,23-dihydroxycampesterol",single,23,24).
+bond("(22R,23R)-22,23-dihydroxycampesterol",singleR,23,32). bond("(22R,23R)-22,23-dihydroxycampesterol",single,24,25). bond("(22R,23R)-22,23-dihydroxycampesterol",singleR,24,35).
+bond("(22R,23R)-22,23-dihydroxycampesterol",single,25,26). bond("(22R,23R)-22,23-dihydroxycampesterol",single,25,27).
+
+atom("campest-4-en-3β-ol",1..27,carb).  atom("campest-4-en-3β-ol",30,carb). atom("campest-4-en-3β-ol",31,oxyg).
+atom("campest-4-en-3β-ol",35,carb).
+bond("campest-4-en-3β-ol",single,1,2). bond("campest-4-en-3β-ol",single,1,10). bond("campest-4-en-3β-ol",single,2,3).
+bond("campest-4-en-3β-ol",single,3,4). bond("campest-4-en-3β-ol",singleR,3,31). bond("campest-4-en-3β-ol",double,4,5).
+bond("campest-4-en-3β-ol",single,5,6). bond("campest-4-en-3β-ol",single,5,10). bond("campest-4-en-3β-ol",single,6,7).
+bond("campest-4-en-3β-ol",single,7,8). bond("campest-4-en-3β-ol",single,8,9). bond("campest-4-en-3β-ol",single,8,14).
+bond("campest-4-en-3β-ol",single,9,10). bond("campest-4-en-3β-ol",single,9,11). bond("campest-4-en-3β-ol",singleR,10,19).
+bond("campest-4-en-3β-ol",single,11,12). bond("campest-4-en-3β-ol",single,12,13). bond("campest-4-en-3β-ol",single,13,14).
+bond("campest-4-en-3β-ol",single,14,15). bond("campest-4-en-3β-ol",singleS,14,30). bond("campest-4-en-3β-ol",single,15,16).
+bond("campest-4-en-3β-ol",single,16,17). bond("campest-4-en-3β-ol",single,13,17). bond("campest-4-en-3β-ol",singleR,13,18).
+bond("campest-4-en-3β-ol",singleR,17,20). bond("campest-4-en-3β-ol",singleS,20,21). bond("campest-4-en-3β-ol",single,20,22).
+bond("campest-4-en-3β-ol",single,22,23). bond("campest-4-en-3β-ol",single,23,24). bond("campest-4-en-3β-ol",single,24,25).
+bond("campest-4-en-3β-ol",singleR,24,35). bond("campest-4-en-3β-ol",single,25,26). bond("campest-4-en-3β-ol",single,25,27).
+
+atom("campest-4-en-3-one",1..27,carb).  atom("campest-4-en-3-one",30,carb). atom("campest-4-en-3-one",31,oxyg).
+atom("campest-4-en-3-one",35,carb).
+bond("campest-4-en-3-one",single,1,2). bond("campest-4-en-3-one",single,1,10). bond("campest-4-en-3-one",single,2,3).
+bond("campest-4-en-3-one",single,3,4). bond("campest-4-en-3-one",double,3,31). bond("campest-4-en-3-one",double,4,5).
+bond("campest-4-en-3-one",single,5,6). bond("campest-4-en-3-one",single,5,10). bond("campest-4-en-3-one",single,6,7).
+bond("campest-4-en-3-one",single,7,8). bond("campest-4-en-3-one",single,8,9). bond("campest-4-en-3-one",single,8,14).
+bond("campest-4-en-3-one",single,9,10). bond("campest-4-en-3-one",single,9,11). bond("campest-4-en-3-one",singleR,10,19).
+bond("campest-4-en-3-one",single,11,12). bond("campest-4-en-3-one",single,12,13). bond("campest-4-en-3-one",single,13,14).
+bond("campest-4-en-3-one",single,14,15). bond("campest-4-en-3-one",singleS,14,30). bond("campest-4-en-3-one",single,15,16).
+bond("campest-4-en-3-one",single,16,17). bond("campest-4-en-3-one",single,13,17). bond("campest-4-en-3-one",singleR,13,18).
+bond("campest-4-en-3-one",singleR,17,20). bond("campest-4-en-3-one",singleS,20,21). bond("campest-4-en-3-one",single,20,22).
+bond("campest-4-en-3-one",single,22,23). bond("campest-4-en-3-one",single,23,24). bond("campest-4-en-3-one",single,24,25).
+bond("campest-4-en-3-one",singleR,24,35). bond("campest-4-en-3-one",single,25,26). bond("campest-4-en-3-one",single,25,27).
+
+atom("(5α)-campestan-3-one",1..27,carb).  atom("(5α)-campestan-3-one",30,carb). atom("(5α)-campestan-3-one",31,oxyg).
+atom("(5α)-campestan-3-one",35,carb).
+bond("(5α)-campestan-3-one",single,1,2). bond("(5α)-campestan-3-one",single,1,10). bond("(5α)-campestan-3-one",single,2,3).
+bond("(5α)-campestan-3-one",single,3,4). bond("(5α)-campestan-3-one",double,3,31). bond("(5α)-campestan-3-one",single,4,5).
+bond("(5α)-campestan-3-one",single,5,6). bond("(5α)-campestan-3-one",single,5,10). bond("(5α)-campestan-3-one",single,6,7).
+bond("(5α)-campestan-3-one",single,7,8). bond("(5α)-campestan-3-one",single,8,9). bond("(5α)-campestan-3-one",single,8,14).
+bond("(5α)-campestan-3-one",single,9,10). bond("(5α)-campestan-3-one",single,9,11). bond("(5α)-campestan-3-one",singleR,10,19).
+bond("(5α)-campestan-3-one",single,11,12). bond("(5α)-campestan-3-one",single,12,13). bond("(5α)-campestan-3-one",single,13,14).
+bond("(5α)-campestan-3-one",single,14,15). bond("(5α)-campestan-3-one",singleS,14,30). bond("(5α)-campestan-3-one",single,15,16).
+bond("(5α)-campestan-3-one",single,16,17). bond("(5α)-campestan-3-one",single,13,17). bond("(5α)-campestan-3-one",singleR,13,18).
+bond("(5α)-campestan-3-one",singleR,17,20). bond("(5α)-campestan-3-one",singleS,20,21). bond("(5α)-campestan-3-one",single,20,22).
+bond("(5α)-campestan-3-one",single,22,23). bond("(5α)-campestan-3-one",single,23,24). bond("(5α)-campestan-3-one",single,24,25).
+bond("(5α)-campestan-3-one",singleR,24,35). bond("(5α)-campestan-3-one",single,25,26). bond("(5α)-campestan-3-one",single,25,27).
+
+atom("campestanol",1..27,carb).  atom("campestanol",30,carb). atom("campestanol",31,oxyg).
+atom("campestanol",35,carb).
+bond("campestanol",single,1,2). bond("campestanol",single,1,10). bond("campestanol",single,2,3).
+bond("campestanol",single,3,4). bond("campestanol",singleR,3,31). bond("campestanol",single,4,5).
+bond("campestanol",single,5,6). bond("campestanol",single,5,10). bond("campestanol",single,6,7).
+bond("campestanol",single,7,8). bond("campestanol",single,8,9). bond("campestanol",single,8,14).
+bond("campestanol",single,9,10). bond("campestanol",single,9,11). bond("campestanol",singleR,10,19).
+bond("campestanol",single,11,12). bond("campestanol",single,12,13). bond("campestanol",single,13,14).
+bond("campestanol",single,14,15). bond("campestanol",singleS,14,30). bond("campestanol",single,15,16).
+bond("campestanol",single,16,17). bond("campestanol",single,13,17). bond("campestanol",singleR,13,18).
+bond("campestanol",singleR,17,20). bond("campestanol",singleS,20,21). bond("campestanol",single,20,22).
+bond("campestanol",single,22,23). bond("campestanol",single,23,24). bond("campestanol",single,24,25).
+bond("campestanol",singleR,24,35). bond("campestanol",single,25,26). bond("campestanol",single,25,27).
+
+atom("6-deoxocathasterone",1..27,carb).  atom("6-deoxocathasterone",30,carb). atom("6-deoxocathasterone",31,oxyg).
+atom("6-deoxocathasterone",34,oxyg). atom("6-deoxocathasterone",35,carb).
+bond("6-deoxocathasterone",single,1,2). bond("6-deoxocathasterone",single,1,10). bond("6-deoxocathasterone",single,2,3).
+bond("6-deoxocathasterone",single,3,4). bond("6-deoxocathasterone",singleR,3,31). bond("6-deoxocathasterone",single,4,5).
+bond("6-deoxocathasterone",single,5,6). bond("6-deoxocathasterone",single,5,10). bond("6-deoxocathasterone",single,6,7).
+bond("6-deoxocathasterone",single,7,8). bond("6-deoxocathasterone",single,8,9). bond("6-deoxocathasterone",single,8,14).
+bond("6-deoxocathasterone",single,9,10). bond("6-deoxocathasterone",single,9,11). bond("6-deoxocathasterone",singleR,10,19).
+bond("6-deoxocathasterone",single,11,12). bond("6-deoxocathasterone",single,12,13). bond("6-deoxocathasterone",single,13,14).
+bond("6-deoxocathasterone",single,14,15). bond("6-deoxocathasterone",singleS,14,30). bond("6-deoxocathasterone",single,15,16).
+bond("6-deoxocathasterone",single,16,17). bond("6-deoxocathasterone",single,13,17). bond("6-deoxocathasterone",singleR,13,18).
+bond("6-deoxocathasterone",singleR,17,20). bond("6-deoxocathasterone",singleS,20,21). bond("6-deoxocathasterone",single,20,22).
+bond("6-deoxocathasterone",single,22,23). bond("6-deoxocathasterone",singleR,22,34). bond("6-deoxocathasterone",single,23,24).
+bond("6-deoxocathasterone",single,24,25). bond("6-deoxocathasterone",singleR,24,35). bond("6-deoxocathasterone",single,25,26).
+bond("6-deoxocathasterone",single,25,27).
+
+atom("6-deoxoteasterone",1..27,carb).  atom("6-deoxoteasterone",30,carb). atom("6-deoxoteasterone",31,oxyg).
+atom("6-deoxoteasterone",32,oxyg). atom("6-deoxoteasterone",34,oxyg). atom("6-deoxoteasterone",35,carb).
+bond("6-deoxoteasterone",single,1,2). bond("6-deoxoteasterone",single,1,10). bond("6-deoxoteasterone",single,2,3).
+bond("6-deoxoteasterone",single,3,4). bond("6-deoxoteasterone",singleR,3,31). bond("6-deoxoteasterone",single,4,5).
+bond("6-deoxoteasterone",single,5,6). bond("6-deoxoteasterone",single,5,10). bond("6-deoxoteasterone",single,6,7).
+bond("6-deoxoteasterone",single,7,8). bond("6-deoxoteasterone",single,8,9). bond("6-deoxoteasterone",single,8,14).
+bond("6-deoxoteasterone",single,9,10). bond("6-deoxoteasterone",single,9,11). bond("6-deoxoteasterone",singleR,10,19).
+bond("6-deoxoteasterone",single,11,12). bond("6-deoxoteasterone",single,12,13). bond("6-deoxoteasterone",single,13,14).
+bond("6-deoxoteasterone",single,14,15). bond("6-deoxoteasterone",singleS,14,30). bond("6-deoxoteasterone",single,15,16).
+bond("6-deoxoteasterone",single,16,17). bond("6-deoxoteasterone",single,13,17). bond("6-deoxoteasterone",singleR,13,18).
+bond("6-deoxoteasterone",singleR,17,20). bond("6-deoxoteasterone",singleS,20,21). bond("6-deoxoteasterone",single,20,22).
+bond("6-deoxoteasterone",single,22,23). bond("6-deoxoteasterone",singleR,22,34). bond("6-deoxoteasterone",single,23,24).
+bond("6-deoxoteasterone",singleR,23,32). bond("6-deoxoteasterone",single,24,25). bond("6-deoxoteasterone",singleR,24,35).
+bond("6-deoxoteasterone",single,25,26). bond("6-deoxoteasterone",single,25,27).
+
+atom("3-dehydro-6-deoxoteasterone",1..27,carb).  atom("3-dehydro-6-deoxoteasterone",30,carb). atom("3-dehydro-6-deoxoteasterone",31,oxyg).
+atom("3-dehydro-6-deoxoteasterone",32,oxyg). atom("3-dehydro-6-deoxoteasterone",34,oxyg). atom("3-dehydro-6-deoxoteasterone",35,carb).
+bond("3-dehydro-6-deoxoteasterone",single,1,2). bond("3-dehydro-6-deoxoteasterone",single,1,10). bond("3-dehydro-6-deoxoteasterone",single,2,3).
+bond("3-dehydro-6-deoxoteasterone",single,3,4). bond("3-dehydro-6-deoxoteasterone",double,3,31). bond("3-dehydro-6-deoxoteasterone",single,4,5).
+bond("3-dehydro-6-deoxoteasterone",single,5,6). bond("3-dehydro-6-deoxoteasterone",single,5,10). bond("3-dehydro-6-deoxoteasterone",single,6,7).
+bond("3-dehydro-6-deoxoteasterone",single,7,8). bond("3-dehydro-6-deoxoteasterone",single,8,9). bond("3-dehydro-6-deoxoteasterone",single,8,14).
+bond("3-dehydro-6-deoxoteasterone",single,9,10). bond("3-dehydro-6-deoxoteasterone",single,9,11). bond("3-dehydro-6-deoxoteasterone",singleR,10,19).
+bond("3-dehydro-6-deoxoteasterone",single,11,12). bond("3-dehydro-6-deoxoteasterone",single,12,13). bond("3-dehydro-6-deoxoteasterone",single,13,14).
+bond("3-dehydro-6-deoxoteasterone",single,14,15). bond("3-dehydro-6-deoxoteasterone",singleS,14,30). bond("3-dehydro-6-deoxoteasterone",single,15,16).
+bond("3-dehydro-6-deoxoteasterone",single,16,17). bond("3-dehydro-6-deoxoteasterone",single,13,17). bond("3-dehydro-6-deoxoteasterone",singleR,13,18).
+bond("3-dehydro-6-deoxoteasterone",singleR,17,20). bond("3-dehydro-6-deoxoteasterone",singleS,20,21). bond("3-dehydro-6-deoxoteasterone",single,20,22).
+bond("3-dehydro-6-deoxoteasterone",single,22,23). bond("3-dehydro-6-deoxoteasterone",singleR,22,34). bond("3-dehydro-6-deoxoteasterone",single,23,24).
+bond("3-dehydro-6-deoxoteasterone",singleR,23,32). bond("3-dehydro-6-deoxoteasterone",single,24,25). bond("3-dehydro-6-deoxoteasterone",singleR,24,35).
+bond("3-dehydro-6-deoxoteasterone",single,25,26). bond("3-dehydro-6-deoxoteasterone",single,25,27).
+
 % Information necessary to infer new 23 hydroxylation
 atom("(22α)-hydroxy-campest-4-en-3-one",1..27,carb).  atom("(22α)-hydroxy-campest-4-en-3-one",30,carb). atom("(22α)-hydroxy-campest-4-en-3-one",31,oxyg).
 atom("(22α)-hydroxy-campest-4-en-3-one",34,oxyg). atom("(22α)-hydroxy-campest-4-en-3-one",35,carb).
@@ -357,6 +504,51 @@ bond("(22R,23R)-22,23-dihydroxy-campest-4-en-3-one",singleR,17,20). bond("(22R,2
 bond("(22R,23R)-22,23-dihydroxy-campest-4-en-3-one",singleR,22,34). bond("(22R,23R)-22,23-dihydroxy-campest-4-en-3-one",single,22,23). bond("(22R,23R)-22,23-dihydroxy-campest-4-en-3-one",single,23,24).
 bond("(22R,23R)-22,23-dihydroxy-campest-4-en-3-one",singleR,23,32). bond("(22R,23R)-22,23-dihydroxy-campest-4-en-3-one",single,24,25). bond("(22R,23R)-22,23-dihydroxy-campest-4-en-3-one",singleR,24,35). 
 bond("(22R,23R)-22,23-dihydroxy-campest-4-en-3-one",single,25,26). bond("(22R,23R)-22,23-dihydroxy-campest-4-en-3-one",single,25,27).
+
+atom("(22S,24R)-22-hydroxy-5α-ergostan-3-one",1..27,carb).  atom("(22S,24R)-22-hydroxy-5α-ergostan-3-one",30,carb). atom("(22S,24R)-22-hydroxy-5α-ergostan-3-one",31,oxyg).
+atom("(22S,24R)-22-hydroxy-5α-ergostan-3-one",34,oxyg). atom("(22S,24R)-22-hydroxy-5α-ergostan-3-one",35,carb).
+bond("(22S,24R)-22-hydroxy-5α-ergostan-3-one",single,1,2). bond("(22S,24R)-22-hydroxy-5α-ergostan-3-one",single,1,10). bond("(22S,24R)-22-hydroxy-5α-ergostan-3-one",single,2,3).
+bond("(22S,24R)-22-hydroxy-5α-ergostan-3-one",single,3,4). bond("(22S,24R)-22-hydroxy-5α-ergostan-3-one",double,3,31). bond("(22S,24R)-22-hydroxy-5α-ergostan-3-one",single,4,5).
+bond("(22S,24R)-22-hydroxy-5α-ergostan-3-one",single,5,6). bond("(22S,24R)-22-hydroxy-5α-ergostan-3-one",single,5,10). bond("(22S,24R)-22-hydroxy-5α-ergostan-3-one",single,6,7).
+bond("(22S,24R)-22-hydroxy-5α-ergostan-3-one",single,7,8). bond("(22S,24R)-22-hydroxy-5α-ergostan-3-one",single,8,9). bond("(22S,24R)-22-hydroxy-5α-ergostan-3-one",single,8,14).
+bond("(22S,24R)-22-hydroxy-5α-ergostan-3-one",single,9,10). bond("(22S,24R)-22-hydroxy-5α-ergostan-3-one",single,9,11). bond("(22S,24R)-22-hydroxy-5α-ergostan-3-one",singleR,10,19).
+bond("(22S,24R)-22-hydroxy-5α-ergostan-3-one",single,11,12). bond("(22S,24R)-22-hydroxy-5α-ergostan-3-one",single,12,13). bond("(22S,24R)-22-hydroxy-5α-ergostan-3-one",single,13,14).
+bond("(22S,24R)-22-hydroxy-5α-ergostan-3-one",single,14,15). bond("(22S,24R)-22-hydroxy-5α-ergostan-3-one",singleS,14,30). bond("(22S,24R)-22-hydroxy-5α-ergostan-3-one",single,15,16).
+bond("(22S,24R)-22-hydroxy-5α-ergostan-3-one",single,16,17). bond("(22S,24R)-22-hydroxy-5α-ergostan-3-one",single,13,17). bond("(22S,24R)-22-hydroxy-5α-ergostan-3-one",singleR,13,18).
+bond("(22S,24R)-22-hydroxy-5α-ergostan-3-one",singleR,17,20). bond("(22S,24R)-22-hydroxy-5α-ergostan-3-one",singleS,20,21). bond("(22S,24R)-22-hydroxy-5α-ergostan-3-one",single,20,22).
+bond("(22S,24R)-22-hydroxy-5α-ergostan-3-one",singleR,22,34). bond("(22S,24R)-22-hydroxy-5α-ergostan-3-one",single,22,23). bond("(22S,24R)-22-hydroxy-5α-ergostan-3-one",single,23,24).
+bond("(22S,24R)-22-hydroxy-5α-ergostan-3-one",single,24,25). bond("(22S,24R)-22-hydroxy-5α-ergostan-3-one",singleR,24,35). bond("(22S,24R)-22-hydroxy-5α-ergostan-3-one",single,25,26).
+bond("(22S,24R)-22-hydroxy-5α-ergostan-3-one",single,25,27).
+
+atom("3-epi-6-deoxocathasterone",1..27,carb).  atom("3-epi-6-deoxocathasterone",30,carb). atom("3-epi-6-deoxocathasterone",31,oxyg).
+atom("3-epi-6-deoxocathasterone",34,oxyg). atom("3-epi-6-deoxocathasterone",35,carb).
+bond("3-epi-6-deoxocathasterone",single,1,2). bond("3-epi-6-deoxocathasterone",single,1,10). bond("3-epi-6-deoxocathasterone",single,2,3).
+bond("3-epi-6-deoxocathasterone",single,3,4). bond("3-epi-6-deoxocathasterone",singleS,3,31). bond("3-epi-6-deoxocathasterone",single,4,5).
+bond("3-epi-6-deoxocathasterone",single,5,6). bond("3-epi-6-deoxocathasterone",single,5,10). bond("3-epi-6-deoxocathasterone",single,6,7).
+bond("3-epi-6-deoxocathasterone",single,7,8). bond("3-epi-6-deoxocathasterone",single,8,9). bond("3-epi-6-deoxocathasterone",single,8,14).
+bond("3-epi-6-deoxocathasterone",single,9,10). bond("3-epi-6-deoxocathasterone",single,9,11). bond("3-epi-6-deoxocathasterone",singleR,10,19).
+bond("3-epi-6-deoxocathasterone",single,11,12). bond("3-epi-6-deoxocathasterone",single,12,13). bond("3-epi-6-deoxocathasterone",single,13,14).
+bond("3-epi-6-deoxocathasterone",single,14,15). bond("3-epi-6-deoxocathasterone",singleS,14,30). bond("3-epi-6-deoxocathasterone",single,15,16).
+bond("3-epi-6-deoxocathasterone",single,16,17). bond("3-epi-6-deoxocathasterone",single,13,17). bond("3-epi-6-deoxocathasterone",singleR,13,18).
+bond("3-epi-6-deoxocathasterone",singleR,17,20). bond("3-epi-6-deoxocathasterone",singleS,20,21). bond("3-epi-6-deoxocathasterone",single,20,22).
+bond("3-epi-6-deoxocathasterone",singleR,22,34). bond("3-epi-6-deoxocathasterone",single,22,23). bond("3-epi-6-deoxocathasterone",single,23,24).
+bond("3-epi-6-deoxocathasterone",single,24,25). bond("3-epi-6-deoxocathasterone",singleR,24,35). bond("3-epi-6-deoxocathasterone",single,25,26).
+bond("3-epi-6-deoxocathasterone",single,25,27).
+
+atom("6-deoxotyphasterol",1..27,carb).  atom("6-deoxotyphasterol",30,carb). atom("6-deoxotyphasterol",31,oxyg).
+atom("6-deoxotyphasterol",32,oxyg). atom("6-deoxotyphasterol",34,oxyg). atom("6-deoxotyphasterol",35,carb).
+bond("6-deoxotyphasterol",single,1,2). bond("6-deoxotyphasterol",single,1,10). bond("6-deoxotyphasterol",single,2,3).
+bond("6-deoxotyphasterol",single,3,4). bond("6-deoxotyphasterol",singleS,3,31). bond("6-deoxotyphasterol",single,4,5).
+bond("6-deoxotyphasterol",single,5,6). bond("6-deoxotyphasterol",single,5,10). bond("6-deoxotyphasterol",single,6,7).
+bond("6-deoxotyphasterol",single,7,8). bond("6-deoxotyphasterol",single,8,9). bond("6-deoxotyphasterol",single,8,14).
+bond("6-deoxotyphasterol",single,9,10). bond("6-deoxotyphasterol",single,9,11). bond("6-deoxotyphasterol",singleR,10,19).
+bond("6-deoxotyphasterol",single,11,12). bond("6-deoxotyphasterol",single,12,13). bond("6-deoxotyphasterol",single,13,14).
+bond("6-deoxotyphasterol",single,14,15). bond("6-deoxotyphasterol",singleS,14,30). bond("6-deoxotyphasterol",single,15,16).
+bond("6-deoxotyphasterol",single,16,17). bond("6-deoxotyphasterol",single,13,17). bond("6-deoxotyphasterol",singleR,13,18).
+bond("6-deoxotyphasterol",singleR,17,20). bond("6-deoxotyphasterol",singleS,20,21). bond("6-deoxotyphasterol",single,20,22).
+bond("6-deoxotyphasterol",single,22,23). bond("6-deoxotyphasterol",singleR,22,34). bond("6-deoxotyphasterol",single,23,24).
+bond("6-deoxotyphasterol",singleR,23,32). bond("6-deoxotyphasterol",single,24,25). bond("6-deoxotyphasterol",singleR,24,35).
+bond("6-deoxotyphasterol",single,25,26). bond("6-deoxotyphasterol",single,25,27).
 
 % New inferred intermediates
 
@@ -477,8 +669,35 @@ reaction(rxn_12714, "androst-4-ene-3,17-dione", "androsta-1,4-diene-3,17-dione")
 % corresponding metacyc general reactions (EC 1.3.99.4)
 reaction(rxn_3_OXOSTEROID_1_DEHYDROGENASE_RXN, "a 3-oxosteroid", "a 3-oxo-Δ1-steroid").
 
+% PWY-2582: brassinosteroid biosynthesis II
+reaction(rxn_4225,"campesterol","(22α)-hydroxy-campesterol").
+reaction(rxn_4226,"(22α)-hydroxy-campesterol","(22α)-hydroxy-campest-4-en-3-one").
+reaction(rxn_11529,"(22α)-hydroxy-campest-4-en-3-one","(22R,23R)-22,23-dihydroxycampesterol").
+reaction(rxn_11533,"(22R,23R)-22,23-dihydroxycampesterol","(22R,23R)-22,23-dihydroxy-campest-4-en-3-one").
+
+reaction(rxn_709,"campesterol","campest-4-en-3β-ol").
+reaction(rxn_710,"campest-4-en-3β-ol","campest-4-en-3-one").
+reaction(rxn_4231,"campest-4-en-3-one","(22α)-hydroxy-campest-4-en-3-one").
+reaction(rxn_711,"campest-4-en-3-one","(5α)-campestan-3-one").
+reaction(rxn_712,"(5α)-campestan-3-one","campestanol").
+reaction(rxn_773,"campestanol","6-deoxocathasterone").
+reaction(rxn_4228,"(22S,24R)-22-hydroxy-5α-ergostan-3-one","6-deoxocathasterone").
+reaction(rxn_774,"6-deoxocathasterone","6-deoxoteasterone").
+reaction(rxn_775,"6-deoxoteasterone","3-dehydro-6-deoxoteasterone").
+reaction(rxn_11101,"(22S,24R)-22-hydroxy-5α-ergostan-3-one","3-dehydro-6-deoxoteasterone").
+
 % Information necessary to infer new 23 hydroxylation
 reaction(rxn_11530, "(22α)-hydroxy-campest-4-en-3-one", "(22R,23R)-22,23-dihydroxy-campest-4-en-3-one").
+
+reaction(rxn_11534,"(22R,23R)-22,23-dihydroxy-campest-4-en-3-one","3-dehydro-6-deoxoteasterone").
+
+reaction(rxn_4230,"(5α)-campestan-3-one","(22S,24R)-22-hydroxy-5α-ergostan-3-one").
+reaction(rxn_4229,"(22α)-hydroxy-campest-4-en-3-one","(22S,24R)-22-hydroxy-5α-ergostan-3-one").
+
+reaction(rxn_11532,"(22S,24R)-22-hydroxy-5α-ergostan-3-one","3-epi-6-deoxocathasterone").
+
+reaction(rxn_776,"3-dehydro-6-deoxoteasterone","6-deoxotyphasterol").
+reaction(rxn_11531,"3-epi-6-deoxocathasterone","6-deoxotyphasterol").
 
 %*
 Information necessary to infer new 23 dehydrogenation

--- a/pathmodel/data/mozukulins_pwy.lp
+++ b/pathmodel/data/mozukulins_pwy.lp
@@ -261,6 +261,7 @@ reaction(rxn_21827, "(3β,9β)-4α-demethyl-4α-methylhydroxy-9,19-cyclolanost-2
 reaction(rxn_21828, "(3β,9β)-4α-demethyl-4α-formyl-9,19-cyclolanost-24-en-3-ol", "(3β,9β)-4α-demethyl-4α-carboxy-9,19-cyclolanost-24-en-3-ol").
 reaction(rxn_21830, "(3β,9β)-4α-demethyl-4α-carboxy-9,19-cyclolanost-24-en-3-ol", "31-norcycloartenone").
 
+% PWY66-4 and PWY-8191
 reaction(rxn66_28, "desmosterol", "cholesterol").
 
 % Information necessary to infer new Δ1-2 reduction
@@ -280,10 +281,6 @@ The candidate enzyme could belong either to the short-chain dehydrogenase family
 Alternatively, the reaction could also be performed by a CYP enzyme in a CYP85 or CYP90A-like manner.
 *%
 reaction(new_23_dehydrogenation, "23-hydroxy-Δ1-2-31-norcycloartenone", "mozukulin A").
-
-% PWY66-4 and PWY-8191
-reaction(rxn66_28, "desmosterol", "cholesterol").
-
 
 % Source molecule for inference.
 

--- a/pathmodel/pathmodel_wrapper.py
+++ b/pathmodel/pathmodel_wrapper.py
@@ -170,6 +170,7 @@ def pathmodel_analysis(input_file, output_folder, step_limit=None):
     if step_limit:
         str_step_limit = "step_limit("+str(step_limit)+")."
     else:
+        step_limit = 100
         str_step_limit = "step_limit(100)."
 
     # Merge input files + result from MZ prediction and reaction creation into a string, which will be the input file for PathModel.

--- a/pathmodel/plotting.py
+++ b/pathmodel/plotting.py
@@ -174,7 +174,7 @@ def create_rdkit_molecule(molecule_name, molecules, molecule_numberings, bonds):
     rdmol = Chem.Mol()
     rdedmol = Chem.EditableMol(rdmol)
 
-    atoms = sorted(molecules[molecule_name])
+    atoms = {atom_tuple[0]: atom_tuple[1] for atom_tuple in sorted(molecules[molecule_name])}
     atom_numberings = sorted(molecule_numberings[molecule_name])
     # Renumber atom so there is no atom with a number superior to the number of atoms in the molecule.
     atom_replaces = {}
@@ -188,18 +188,18 @@ def create_rdkit_molecule(molecule_name, molecules, molecule_numberings, bonds):
     rdedmol.AddAtom(rdatom)
 
     # Add atoms from the molecule.
-    for atom in atoms:
-        rdatom = Chem.Atom(atom[1])
+    # Add absent atoms to keep the atom numbering.
+    for atom_number in range(max(atom_numberings)):
+        atom_number += 1
+        if atom_number in atoms:
+            atom = atoms[atom_number]
+        else:
+            atom = 0
+        rdatom = Chem.Atom(atom)
         rdedmol.AddAtom(rdatom)
 
     # Add bonds from the molecule.
     for bond in bonds[molecule_name]:
-        # Renumber the bond with the changes made in atom numbering.
-        bond = list(bond)
-        if bond[0] in atom_replaces:
-            bond[0] = atom_replaces[bond[0]]
-        if bond[1] in atom_replaces:
-            bond[1] = atom_replaces[bond[1]]
         bond = tuple(bond)
         rdedmol.AddBond(bond[0],
                         bond[1],

--- a/pathmodel/plotting.py
+++ b/pathmodel/plotting.py
@@ -41,13 +41,13 @@ def run_pathway_creation():
     parser_args = parser.parse_args()
 
     input_folder = parser_args.input_folder
-    pathmodel_output_file = input_folder + '/' + 'pathmodel_output.lp'
+    pathmodel_output_file = os.path.join(input_folder, 'pathmodel_output.lp')
     with open(pathmodel_output_file, 'r') as pathmodel_output:
         asp_code = pathmodel_output.read()
-    picture_name = input_folder + '/' + 'pathmodel_output.svg'
-    input_filename = input_folder + '/' + 'data_pathmodel.lp'
-    output_repository = input_folder + '/molecules'
-    new_output_repository = input_folder + '/newmolecules_from_mz'
+    picture_name = os.path.join(input_folder, 'pathmodel_output.svg')
+    input_filename = os.path.join(input_folder, 'data_pathmodel.lp')
+    output_repository = os.path.join(input_folder, 'molecules')
+    new_output_repository = os.path.join(input_folder, 'newmolecules_from_mz')
 
     # Check if output folder exists if not create it.
     check_folder(output_repository)
@@ -322,7 +322,8 @@ def create_2dmolecule(input_filename, output_directory, align_domain=None):
         # Draw molecule.
         molecule_name = molecule_name
         print(molecule_name)
-        Draw.MolToFile(rdmol, output_directory+'/'+molecule_name+'.svg', size=(800, 800), includeAtomNumbers=True)
+        output_molecule_path = os.path.join(output_directory, molecule_name+'.svg')
+        Draw.MolToFile(rdmol, output_molecule_path, size=(800, 800), includeAtomNumbers=True)
 
     input_file.close()
 

--- a/pathmodel/plotting.py
+++ b/pathmodel/plotting.py
@@ -236,7 +236,8 @@ def create_2dmolecule(input_filename, output_directory, align_domain=None):
     atomicNumber = {'carb': 6,
                     'nitr': 7,
                     'oxyg': 8,
-                    'phos': 15}
+                    'phos': 15,
+                    'variable': 0}
 
     if align_domain:
         domain_molecules = {}

--- a/pathmodel/plotting.py
+++ b/pathmodel/plotting.py
@@ -36,7 +36,7 @@ def run_pathway_creation():
     Functions handling the argument parsing of pathmodel_plot.
     """
     parser = argparse.ArgumentParser(description="Plot molecules and reactions inferred by PathModel.")
-    parser.add_argument("-i", "--input", dest="input_folder", metavar="FILE", help="Input folder corresponds to the output folder of pathmodel.")
+    parser.add_argument("-i", "--input", dest="input_folder", metavar="FOLDER", help="Input folder corresponds to the output folder of pathmodel.")
 
     parser_args = parser.parse_args()
 

--- a/pathmodel/plotting.py
+++ b/pathmodel/plotting.py
@@ -30,7 +30,11 @@ try:
 except ImportError:
     raise ImportError("Requires graphviz (https://www.graphviz.org/) and pygraphviz (https://pygraphviz.github.io/).")
 
+
 def run_pathway_creation():
+    """
+    Functions handling the argument parsing of pathmodel_plot.
+    """
     parser = argparse.ArgumentParser(description="Plot molecules and reactions inferred by PathModel.")
     parser.add_argument("-i", "--input", dest="input_folder", metavar="FILE", help="Input folder corresponds to the output folder of pathmodel.")
 
@@ -60,6 +64,14 @@ def run_pathway_creation():
 
 
 def pathmodel_pathway_picture(asp_code, picture_name, input_filename):
+    """
+    Create the pathway picture using ASP results code from PathModel inference.
+
+    Args:
+        asp_code (str): string containing PathModel results
+        picture_name (str): path to the output picture file
+        input_filename (str): path to PathModel intermediary file
+    """
     DG = nx.DiGraph()
 
     known_compounds = []
@@ -145,9 +157,18 @@ def pathmodel_pathway_picture(asp_code, picture_name, input_filename):
     extension = os.path.splitext(picture_name)[1].strip('.')
     plt.savefig(picture_name, dpi=144, format=extension)
 
+
 def create_rdkit_molecule(molecule_name, molecules, molecule_numberings, bonds):
     '''
     Using dictionaries containing molecule structure create a rdkit molecule.
+
+    Args:
+        molecule_name (str): name of a molecule
+        molecules (dict): dictionary containing for each molecules a list with a atom numbers and types in the molecule
+        molecule_numberings (dict): dictionary containing for each molecules a list with a atom numbers in the molecule
+        bonds (dict): dictionary containing for each molecules the list of its bond in utpels (bond_number_1, bond_number_2, bond_type)
+    Returns:
+        rdmol (Mol): the molecule in rdkit Molecule
     '''
     # Create an editable molecule.
     rdmol = Chem.Mol()
@@ -195,6 +216,11 @@ def create_2dmolecule(input_filename, output_directory, align_domain=None):
     From an ASP input file create 2d representation of molecules.
     To use align_domain, you need the intermediate file creates by pathmodel_wrapper.py.
     With align_domain, rdkit will use domain to align molecules.
+
+    Args:
+        input_filename (str): path to PathMoldel output file
+        output_directory (str): output folder containing pictures of the molecuels and of the infered pathway
+        align_domain (bool): if True, rdkit will use domain to align molecules
     '''
     with open(input_filename, 'r') as input_file:
         asp_code = input_file.read()

--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,11 @@
 import os
-from setuptools import setup
+from distutils.util import convert_path
+from setuptools import setup, find_packages
+
+init_data = {}
+init_pathname = convert_path('pathmodel/__init__.py')
+with open(init_pathname) as init_file:
+    exec(init_file.read(), init_data)
 
 setup_directory = os.path.abspath(os.path.dirname(__file__))
 with open(os.path.join(setup_directory, 'README.rst'), encoding='utf-8') as readme_file:
@@ -7,7 +13,7 @@ with open(os.path.join(setup_directory, 'README.rst'), encoding='utf-8') as read
 
 setup(
     name='pathmodel',
-    version='0.1.9',
+    version=init_data['__version__'],
     url='https://github.com/pathmodel/pathmodel',
     description='Ab initio pathway inference',
     long_description=long_description,


### PR DESCRIPTION
## Add

* new argument `step_limit` (`-s` in command line): this argument is used to avoid endless run of PathModel. Indeed, in previous version if the goal molecules could not be reached, the tool continue its prediction trying to reach them. Now, PathModel has a minimal number of step in which the goal molecules must be reached (by default it is 100 steps). The number of step can be modified with this new argument.
* Mozukulin and Brown alga sterol pathways data.
* `CompareMolecules.lp` to compare molecules and check transformations from known reactions.

## Fix

* Issue with atom numbering in `pathmodel_plot`.